### PR TITLE
Added support for 'Meta' keys

### DIFF
--- a/src/lib/get-key-event-name.js
+++ b/src/lib/get-key-event-name.js
@@ -26,6 +26,10 @@ const getKeyEventName = event => {
     keys.push('Ctrl');
   }
 
+  if (event.metaKey) {
+    keys.push('Meta');
+  }
+
   keys.push(keyName);
 
   return keys.join('+');


### PR DESCRIPTION
It seems like the library doesn't have support for MetaKeys (Command on Mac OS, Windows Key on Windows Systems).

Would also be great if you can update the dependency in https://github.com/soska/react-keyboardist after you accepted the pull request :-)