### PR TITLE
v3: react-keyboardist — hooks + components, RSC-safe

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
     { "repo": "soska/keyboardist" }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [["keyboardist", "react-keyboardist"]],
   "linked": [],
   "access": "public",
   "baseBranch": "master",

--- a/.changeset/react-keyboardist-v3.md
+++ b/.changeset/react-keyboardist-v3.md
@@ -1,0 +1,11 @@
+---
+"react-keyboardist": major
+---
+
+react-keyboardist joins the keyboardist monorepo, rewritten for React 18/19 and React Server Components.
+
+- **Hooks API**: `useKeyBindings(map)`, `useKeyboardLayer(map, { exclusive, active })`, `useKeyMonitor(fn)`, and `useElementKeyBindings(ref, map)`.
+- **Components**: `<Keyboardist bindings monitor?>` (still the default export, renders nothing), new `<KeyboardLayer bindings exclusive? active?>` that scopes the keyboard to its children while mounted, and `<KeyboardInput>` (ports the old element-attached input, now with ref forwarding).
+- **RSC/Next.js-safe**: the bundle ships a `'use client'` directive, so components drop straight into server-component trees; listeners are created lazily on first client use (never at module scope), and importing the package is safe without a DOM.
+- **Inline-friendly**: bindings objects can be inline JSX props — callbacks are read through refs and resubscription only happens when the key set changes.
+- Powered by keyboardist 3 layers; versions are now locked to `keyboardist` (3.x pairs with 3.x). Requires React 18 or 19.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ This is a pnpm workspace monorepo:
 | Path | What it is |
 | --- | --- |
 | `packages/keyboardist` | The `keyboardist` npm package |
+| `packages/react-keyboardist` | The `react-keyboardist` npm package (hooks + components) |
 | `apps/website` | The demo/docs website (Vite, deployed to Netlify) |
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ const modal = listener.layer("modal", { escape: close }, { exclusive: true });
 const pop = modal.push();
 ```
 
+## Why
+
+Anyone can write one `keydown` listener. What accumulates after that —
+canonical key names instead of modifier-flag chains, staying quiet while the
+user types into inputs and contenteditables, preventing default only on real
+matches, and above all **layers** (a modal or command palette taking over the
+keyboard and handing it back cleanly, even when overlapping) — is the code
+every app ends up writing badly under deadline. Keyboardist is that code,
+extracted, tested, ~3 kB gzipped with zero dependencies. The longer
+version is in the
+[package README](packages/keyboardist/README.md#why-not-just-addeventlistener).
+
 This is the Keyboardist monorepo:
 
 | Package | Description |

--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ This is the Keyboardist monorepo:
 | Package | Description |
 | --- | --- |
 | [`packages/keyboardist`](packages/keyboardist) | The [`keyboardist`](https://www.npmjs.com/package/keyboardist) npm package — docs live in its [README](packages/keyboardist/README.md) |
+| [`packages/react-keyboardist`](packages/react-keyboardist) | [`react-keyboardist`](https://www.npmjs.com/package/react-keyboardist) — React hooks and components, RSC-safe |
 | [`apps/website`](apps/website) | The demo website |
-
-For using with React, there's
-[React Keyboardist](https://github.com/soska/react-keyboardist).
 
 ## Development
 

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -69,6 +69,18 @@
         </div>
       </div>
       <div class="demo">
+        <h2>React</h2>
+        <div class="instructions">
+          This section is a React island using
+          <a href="https://www.npmjs.com/package/react-keyboardist"
+            >react-keyboardist</a
+          >
+          — hooks and components over the same shared listener as the vanilla
+          demos above.
+        </div>
+        <div id="react-demo"></div>
+      </div>
+      <div class="demo">
         <h2>Listening on an input element</h2>
         <div class="instructions">
           Instructions: Click inside the input to focus. Then use up and down

--- a/apps/website/index.js
+++ b/apps/website/index.js
@@ -1,5 +1,6 @@
 import { createListener } from "keyboardist";
 import { highlight, languages } from "prismjs";
+import { mountReactDemo } from "./react-demo";
 import "./styles.css";
 import "prismjs/themes/prism-okaidia.css";
 
@@ -28,7 +29,9 @@ const monitor = ({ keyName, matched, layer }) => {
   }, 900);
 };
 
-listener.setMonitor(monitor);
+// The React island owns the listener's single monitor slot and forwards
+// events to our vanilla monitor display (see react-demo.tsx).
+mountReactDemo(document.getElementById("react-demo"), { onMonitor: monitor });
 
 // The demo keys live on a "player" layer, registered as a map.
 // Key names are the friendly canonical spellings.

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -10,11 +10,17 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
     "typescript": "^7.0.2",
     "vite": "^8.1.5"
   },
   "dependencies": {
     "keyboardist": "workspace:^",
-    "prismjs": "^1.30.0"
+    "prismjs": "^1.30.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-keyboardist": "workspace:^"
   }
 }

--- a/apps/website/react-demo.tsx
+++ b/apps/website/react-demo.tsx
@@ -1,0 +1,71 @@
+import type { MonitorCallback } from "keyboardist";
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  KeyboardLayer,
+  useKeyBindings,
+  useKeyMonitor,
+} from "react-keyboardist";
+
+function ReactModal({ onClose }: { onClose: () => void }) {
+  return (
+    <KeyboardLayer bindings={{ escape: onClose }} exclusive>
+      <div className="layer-modal open">
+        <div className="layer-modal-box">
+          <h3>React modal layer</h3>
+          <p>
+            This modal is a React component wrapped in{" "}
+            <code>&lt;KeyboardLayer exclusive&gt;</code>. The vanilla player
+            keys above are inert right now — same listener, same stack. Press{" "}
+            <strong>Esc</strong> to close.
+          </p>
+        </div>
+      </div>
+    </KeyboardLayer>
+  );
+}
+
+function ReactDemo({ onMonitor }: { onMonitor?: MonitorCallback }) {
+  const [count, setCount] = useState(0);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [lastKey, setLastKey] = useState<string>("—");
+
+  useKeyBindings({
+    "shift+r": () => setCount((current) => current + 1),
+  });
+
+  // The listener has a single monitor slot; this island takes it over and
+  // keeps the vanilla monitor display fed via onMonitor.
+  useKeyMonitor((info) => {
+    const { keyName, matched, layer } = info;
+    setLastKey(matched ? `${keyName} → "${layer}"` : `${keyName} (no match)`);
+    onMonitor?.(info);
+  });
+
+  return (
+    <div className="react-demo-panel">
+      <p>
+        Counter: <strong>{count}</strong> — press <code>shift+R</code> to
+        increment (bound with <code>useKeyBindings</code>).
+      </p>
+      <p>
+        Last key: <code>{lastKey}</code> (via <code>useKeyMonitor</code>)
+      </p>
+      <button
+        type="button"
+        className="btn btn-secondary"
+        onClick={() => setModalOpen(true)}
+      >
+        Open React modal
+      </button>
+      {modalOpen && <ReactModal onClose={() => setModalOpen(false)} />}
+    </div>
+  );
+}
+
+export function mountReactDemo(
+  element: Element,
+  options: { onMonitor?: MonitorCallback } = {},
+) {
+  createRoot(element).render(<ReactDemo onMonitor={options.onMonitor} />);
+}

--- a/apps/website/styles.css
+++ b/apps/website/styles.css
@@ -100,6 +100,17 @@ h2 {
   box-shadow: rgba(0, 0, 0, 0.5) 0 11px 33px;
 }
 
+.react-demo-panel {
+  padding: 22px;
+  text-align: center;
+}
+
+.react-demo-panel code {
+  background: #f0f0f0;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
 .input {
   border: 1px solid #999;
   padding: 9px 12px;

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -1,11 +1,19 @@
 import { fileURLToPath } from "node:url";
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  plugins: [react()],
   resolve: {
     alias: {
-      // Resolve the workspace package to its source so the demo
+      // Resolve the workspace packages to their source so the demo
       // hot-reloads library changes without a build step.
+      "react-keyboardist": fileURLToPath(
+        new URL(
+          "../../packages/react-keyboardist/src/index.ts",
+          import.meta.url,
+        ),
+      ),
       keyboardist: fileURLToPath(
         new URL("../../packages/keyboardist/src/index.ts", import.meta.url),
       ),

--- a/packages/keyboardist/README.md
+++ b/packages/keyboardist/README.md
@@ -29,6 +29,50 @@ npm install keyboardist
 
 Keyboardist is published as an ES module.
 
+## Why not just addEventListener?
+
+For one shortcut, you don't need a library:
+
+```javascript
+document.addEventListener("keydown", (e) => {
+  if (e.key === "k" && e.metaKey) openPalette();
+});
+```
+
+That's fine — until you add the second shortcut, and the third, and a modal.
+Keyboardist exists because the code above quietly grows five hard problems,
+and every app ends up hand-rolling the same solutions:
+
+- **Key naming.** `event.key` vs `event.code`, layout quirks, modifier
+  combinations, and the `if (e.shiftKey && !e.metaKey && ...)` chains that
+  come with them. Keyboardist gives every combination one canonical,
+  writable name — `"shift+up"`, `"cmd+k"` — and matching is just a map
+  lookup.
+- **Typing vs shortcuts.** Raw listeners fire while the user types into an
+  input, a textarea, or a contenteditable editor. Everyone discovers this in
+  production. Keyboardist ignores editable targets by default (and lets you
+  attach to an input deliberately when that's what you want).
+- **preventDefault discipline.** Swallow too much and you break the browser;
+  too little and the page scrolls when Space was your play button.
+  Keyboardist prevents default only when a binding actually matched.
+- **Modes and modals.** The genuinely hard one. The moment a modal, command
+  palette, or "mode" needs its own keys, you're building a priority system:
+  who wins, what's disabled, and how everything is restored when it closes —
+  including when two modals overlap and close out of order. That's
+  [layers](#layers), and it's the reason this library exists: the ad-hoc
+  version of this (save the old handler, restore it in a closure) is exactly
+  where hand-rolled implementations grow bugs.
+- **Lifecycle.** Subscriptions that clean up after themselves (`unsubscribe`,
+  `using`), multiple handlers per key with predictable order and
+  stop-propagation, and a [monitor](#key-monitor) so you can see what the
+  keyboard is doing instead of sprinkling `console.log` into a raw handler.
+
+All of that for ~3 kB gzipped, zero dependencies, one `addEventListener`
+per listener under the hood, and `false` instead of a crash on the server.
+If your app has one shortcut, keep the raw listener. The day it has three
+and a modal, this is the code you were going to write anyway — already
+tested.
+
 ## Usage
 
 `createListener` returns a listener object. In non-browser environments (e.g.

--- a/packages/react-keyboardist/README.md
+++ b/packages/react-keyboardist/README.md
@@ -1,0 +1,124 @@
+# 🎹⚛️ React Keyboardist
+
+React hooks and components for [keyboardist](https://www.npmjs.com/package/keyboardist) —
+declarative keyboard shortcuts with layers. Zero configuration, RSC-safe.
+
+```jsx
+import { Keyboardist } from "react-keyboardist";
+
+// works directly inside a Next.js server component tree —
+// the package ships its own "use client" boundary
+export default function Page() {
+  return (
+    <>
+      <Keyboardist bindings={{ "cmd+k": openPalette, slash: focusSearch }} />
+      <Content />
+    </>
+  );
+}
+```
+
+## Install
+
+```sh
+npm install react-keyboardist
+```
+
+Requires React 18 or 19. `react-keyboardist` 3.x pairs with `keyboardist` 3.x
+(installed automatically as a dependency).
+
+## Hooks
+
+### useKeyBindings
+
+Global bindings for the lifetime of the component. Inline objects are fine —
+resubscription only happens when the set of keys changes, and callbacks are
+always the latest render's.
+
+```jsx
+import { useKeyBindings } from "react-keyboardist";
+
+function Player() {
+  useKeyBindings({
+    space: togglePlay,
+    "j,k": step, // comma binds aliases
+    "shift+up": volumeUp,
+  });
+  return <>...</>;
+}
+```
+
+Key names follow keyboardist's canonical scheme (`shift+up`, `cmd+k`, `1`);
+raw `event.code` spellings work too.
+
+### useKeyboardLayer
+
+A [keyboardist layer](https://github.com/soska/keyboardist/tree/master/packages/keyboardist#layers)
+scoped to the component: created on mount, pushed while `active` (default
+`true`), disposed on unmount. With `exclusive: true`, unmatched keys go inert —
+perfect for modals.
+
+```jsx
+function SearchModal({ onClose }) {
+  useKeyboardLayer({ escape: onClose }, { exclusive: true });
+  return <dialog open>...</dialog>;
+}
+```
+
+Also returns a handle: `const layer = useKeyboardLayer(...)` →
+`layer.isActive()`, `layer.push()`, `layer.pop()`.
+
+### useKeyMonitor
+
+Observe every key event (one monitor slot per listener — last mounted wins):
+
+```jsx
+useKeyMonitor(({ keyName, matched, layer }) => {
+  setDisplay(matched ? `${keyName} → ${layer}` : keyName);
+});
+```
+
+### useElementKeyBindings
+
+Attach bindings to a specific element — they keep firing while the user types
+in it:
+
+```jsx
+const inputRef = useRef(null);
+useElementKeyBindings(inputRef, { escape: clear, up: next, down: prev });
+return <input ref={inputRef} />;
+```
+
+## Components
+
+Thin wrappers over the hooks, for JSX-first code:
+
+```jsx
+import Keyboardist, { KeyboardLayer, KeyboardInput } from "react-keyboardist";
+
+// global bindings, renders nothing (the classic react-keyboardist API)
+<Keyboardist bindings={{ slash: focusSearch }} monitor={logKeys} />
+
+// scope the keyboard to a subtree while it's mounted
+<KeyboardLayer bindings={{ escape: close }} exclusive>
+  <Modal />
+</KeyboardLayer>
+
+// an input with its own attached listener
+<KeyboardInput bindings={{ up: increment, down: decrement }} ref={inputRef} />
+```
+
+`<KeyboardLayer>` also accepts `active` (boolean) to toggle the layer without
+unmounting, and `name` if you want a stable layer name for introspection.
+
+## Server-side rendering & React Server Components
+
+- The published bundle starts with `'use client'`, so importing any component
+  from a server component automatically creates the client boundary.
+- Listeners are created lazily on first client-side effect — importing the
+  package never touches `window`, and rendering on the server is a no-op.
+- All bindings attach in effects, so SSR + hydration behave correctly.
+
+## License
+
+MIT © [Armando Sosa](https://armandososa.org)

--- a/packages/react-keyboardist/package.json
+++ b/packages/react-keyboardist/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "react-keyboardist",
+  "version": "2.0.2",
+  "description": "React hooks and components for keyboardist — declarative keyboard shortcuts with layers, RSC-safe",
+  "author": "Armando Sosa <arm.sosa@gmail.com>",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "react",
+    "keyboard",
+    "shortcuts",
+    "hotkeys",
+    "hooks"
+  ],
+  "homepage": "https://github.com/soska/keyboardist",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/soska/keyboardist.git",
+    "directory": "packages/react-keyboardist"
+  },
+  "bugs": "https://github.com/soska/keyboardist/issues",
+  "engines": {
+    "node": ">=20.19"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "check:publish": "publint && attw --pack . --profile esm-only && node --input-type=module -e \"import{readFileSync}from'node:fs';if(!readFileSync('dist/index.js','utf8').startsWith('\\\"use client\\\"')&&!readFileSync('dist/index.js','utf8').startsWith(\\\"'use client'\\\")){console.error('missing use client directive');process.exit(1)}\""
+  },
+  "dependencies": {
+    "keyboardist": "workspace:^"
+  },
+  "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.5",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.17",
+    "happy-dom": "^20.11.1",
+    "publint": "^0.3.21",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "tsdown": "^0.22.13",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/react-keyboardist/src/components.tsx
+++ b/packages/react-keyboardist/src/components.tsx
@@ -1,0 +1,87 @@
+import type {
+  BindingMap,
+  KeyboardEventName,
+  MonitorCallback,
+} from "keyboardist";
+import {
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  forwardRef,
+  type ReactNode,
+  useRef,
+} from "react";
+import { useElementKeyBindings } from "./use-element-key-bindings";
+import { useKeyBindings } from "./use-key-bindings";
+import { useKeyMonitor } from "./use-key-monitor";
+import { useKeyboardLayer } from "./use-keyboard-layer";
+
+export interface KeyboardistProps {
+  bindings: BindingMap;
+  monitor?: MonitorCallback;
+  event?: KeyboardEventName;
+}
+
+/**
+ * Declarative global keyboard bindings. Renders nothing.
+ */
+export function Keyboardist({ bindings, monitor, event }: KeyboardistProps) {
+  useKeyBindings(bindings, { event });
+  useKeyMonitor(monitor, { event });
+  return null;
+}
+
+export interface KeyboardLayerProps {
+  bindings: BindingMap;
+  name?: string;
+  exclusive?: boolean;
+  active?: boolean;
+  event?: KeyboardEventName;
+  children?: ReactNode;
+}
+
+/**
+ * Scopes the keyboard to its bindings while mounted (and `active`). Wrap a
+ * modal in an exclusive layer and it owns the keyboard until it unmounts.
+ */
+export function KeyboardLayer({
+  bindings,
+  name,
+  exclusive,
+  active,
+  event,
+  children,
+}: KeyboardLayerProps) {
+  useKeyboardLayer(bindings, { name, exclusive, active, event });
+  return <>{children}</>;
+}
+
+export type KeyboardInputProps = {
+  bindings: BindingMap;
+  event?: KeyboardEventName;
+  component?: ElementType;
+} & Omit<ComponentPropsWithoutRef<"input">, "component">;
+
+/**
+ * Renders an input (or any `component`) with a dedicated listener attached
+ * to it — bindings keep firing while the user types in it.
+ */
+export const KeyboardInput = forwardRef<HTMLElement, KeyboardInputProps>(
+  function KeyboardInput(
+    { bindings, event, component: Component = "input", ...rest },
+    forwardedRef,
+  ) {
+    const innerRef = useRef<Element | null>(null);
+    useElementKeyBindings(innerRef, bindings, { event });
+
+    const setRef = (node: HTMLElement | null) => {
+      innerRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    };
+
+    return <Component ref={setRef} {...rest} />;
+  },
+);

--- a/packages/react-keyboardist/src/index.ts
+++ b/packages/react-keyboardist/src/index.ts
@@ -1,0 +1,37 @@
+"use client";
+
+export type {
+  BindingInfo,
+  BindingMap,
+  KeyboardEventName,
+  KeyboardistListener,
+  Layer,
+  MonitorCallback,
+  MonitorInfo,
+  Subscription,
+  SubscriptionCallback,
+} from "keyboardist";
+export {
+  KeyboardInput,
+  type KeyboardInputProps,
+  Keyboardist,
+  Keyboardist as default,
+  type KeyboardistProps,
+  KeyboardLayer,
+  type KeyboardLayerProps,
+} from "./components";
+export { getSharedListener } from "./shared-listener";
+export {
+  type UseElementKeyBindingsOptions,
+  useElementKeyBindings,
+} from "./use-element-key-bindings";
+export {
+  type UseKeyBindingsOptions,
+  useKeyBindings,
+} from "./use-key-bindings";
+export { type UseKeyMonitorOptions, useKeyMonitor } from "./use-key-monitor";
+export {
+  type KeyboardLayerHandle,
+  type UseKeyboardLayerOptions,
+  useKeyboardLayer,
+} from "./use-keyboard-layer";

--- a/packages/react-keyboardist/src/shared-listener.ts
+++ b/packages/react-keyboardist/src/shared-listener.ts
@@ -1,0 +1,22 @@
+import {
+  createListener,
+  type KeyboardEventName,
+  type KeyboardistListener,
+} from "keyboardist";
+
+// Lazily-created shared listeners, one per event type. Creation only ever
+// happens inside effects (client-side), never at module scope, so importing
+// this package is safe in server environments (SSR / React Server
+// Components).
+const cache = new Map<KeyboardEventName, KeyboardistListener | false>();
+
+export function getSharedListener(
+  event: KeyboardEventName = "keydown",
+): KeyboardistListener | false {
+  let listener = cache.get(event);
+  if (listener === undefined) {
+    listener = createListener(event);
+    cache.set(event, listener);
+  }
+  return listener;
+}

--- a/packages/react-keyboardist/src/use-element-key-bindings.ts
+++ b/packages/react-keyboardist/src/use-element-key-bindings.ts
@@ -3,7 +3,7 @@ import {
   createListener,
   type KeyboardEventName,
 } from "keyboardist";
-import { type RefObject, useEffect } from "react";
+import { type RefObject, useEffect, useState } from "react";
 import { keySignatureOf } from "./use-key-bindings";
 import { useLatest } from "./use-latest";
 
@@ -24,10 +24,16 @@ export function useElementKeyBindings(
   const { event = "keydown" } = options;
   const bindingsRef = useLatest(bindings);
   const keySignature = keySignatureOf(bindings);
+  const [element, setElement] = useState<Element | null>(null);
+
+  useEffect(() => {
+    if (element !== ref.current) {
+      setElement(ref.current);
+    }
+  });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies(keySignature): resubscribes when the key set changes; callbacks are read through bindingsRef
   useEffect(() => {
-    const element = ref.current;
     if (!element) {
       return;
     }
@@ -48,5 +54,5 @@ export function useElementKeyBindings(
       }
       listener.stopListening();
     };
-  }, [ref, event, keySignature, bindingsRef]);
+  }, [element, event, keySignature, bindingsRef]);
 }

--- a/packages/react-keyboardist/src/use-element-key-bindings.ts
+++ b/packages/react-keyboardist/src/use-element-key-bindings.ts
@@ -1,0 +1,52 @@
+import {
+  type BindingMap,
+  createListener,
+  type KeyboardEventName,
+} from "keyboardist";
+import { type RefObject, useEffect } from "react";
+import { keySignatureOf } from "./use-key-bindings";
+import { useLatest } from "./use-latest";
+
+export interface UseElementKeyBindingsOptions {
+  event?: KeyboardEventName;
+}
+
+/**
+ * Attaches a dedicated listener to the element in `ref` — bindings keep
+ * firing while the user types into it (unlike the shared listener, which
+ * ignores keystrokes in editable elements).
+ */
+export function useElementKeyBindings(
+  ref: RefObject<Element | null>,
+  bindings: BindingMap,
+  options: UseElementKeyBindingsOptions = {},
+): void {
+  const { event = "keydown" } = options;
+  const bindingsRef = useLatest(bindings);
+  const keySignature = keySignatureOf(bindings);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies(keySignature): resubscribes when the key set changes; callbacks are read through bindingsRef
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    const listener = createListener(event, element);
+    if (!listener) {
+      return;
+    }
+
+    const subscriptions = Object.keys(bindingsRef.current).map((key) =>
+      listener.subscribe(key, (keyboardEvent) =>
+        bindingsRef.current[key]?.(keyboardEvent),
+      ),
+    );
+
+    return () => {
+      for (const subscription of subscriptions) {
+        subscription.unsubscribe();
+      }
+      listener.stopListening();
+    };
+  }, [ref, event, keySignature, bindingsRef]);
+}

--- a/packages/react-keyboardist/src/use-key-bindings.ts
+++ b/packages/react-keyboardist/src/use-key-bindings.ts
@@ -1,0 +1,49 @@
+import type { BindingMap, KeyboardEventName } from "keyboardist";
+import { useEffect } from "react";
+import { getSharedListener } from "./shared-listener";
+import { useLatest } from "./use-latest";
+
+export interface UseKeyBindingsOptions {
+  event?: KeyboardEventName;
+}
+
+// Dependency signature for a bindings map: resubscribe only when the set of
+// keys changes, not on every inline-object identity change. NUL separator —
+// keys themselves may contain commas ("j,k" aliases).
+export function keySignatureOf(bindings: BindingMap): string {
+  return Object.keys(bindings).sort().join("\u0000");
+}
+
+/**
+ * Subscribes a bindings map on the shared listener while the component is
+ * mounted. Inline objects are fine: callbacks are read through a ref, and
+ * resubscription only happens when the set of keys changes.
+ */
+export function useKeyBindings(
+  bindings: BindingMap,
+  options: UseKeyBindingsOptions = {},
+): void {
+  const { event = "keydown" } = options;
+  const bindingsRef = useLatest(bindings);
+  const keySignature = keySignatureOf(bindings);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies(keySignature): resubscribes when the key set changes; callbacks are read through bindingsRef
+  useEffect(() => {
+    const listener = getSharedListener(event);
+    if (!listener) {
+      return;
+    }
+
+    const subscriptions = Object.keys(bindingsRef.current).map((key) =>
+      listener.subscribe(key, (keyboardEvent) =>
+        bindingsRef.current[key]?.(keyboardEvent),
+      ),
+    );
+
+    return () => {
+      for (const subscription of subscriptions) {
+        subscription.unsubscribe();
+      }
+    };
+  }, [event, keySignature, bindingsRef]);
+}

--- a/packages/react-keyboardist/src/use-key-monitor.ts
+++ b/packages/react-keyboardist/src/use-key-monitor.ts
@@ -3,6 +3,8 @@ import { useEffect } from "react";
 import { getSharedListener } from "./shared-listener";
 import { useLatest } from "./use-latest";
 
+const monitorOwners = new WeakMap<object, symbol>();
+
 export interface UseKeyMonitorOptions {
   event?: KeyboardEventName;
 }
@@ -27,8 +29,14 @@ export function useKeyMonitor(
     if (!listener) {
       return;
     }
+    const owner = Symbol("monitor-owner");
+    monitorOwners.set(listener, owner);
     listener.setMonitor((info) => monitorRef.current?.(info));
     return () => {
+      if (monitorOwners.get(listener) !== owner) {
+        return;
+      }
+      monitorOwners.delete(listener);
       listener.setMonitor(false);
     };
   }, [event, hasMonitor, monitorRef]);

--- a/packages/react-keyboardist/src/use-key-monitor.ts
+++ b/packages/react-keyboardist/src/use-key-monitor.ts
@@ -1,0 +1,35 @@
+import type { KeyboardEventName, MonitorCallback } from "keyboardist";
+import { useEffect } from "react";
+import { getSharedListener } from "./shared-listener";
+import { useLatest } from "./use-latest";
+
+export interface UseKeyMonitorOptions {
+  event?: KeyboardEventName;
+}
+
+/**
+ * Sets the shared listener's monitor while mounted. Note: a listener has a
+ * single monitor slot, so the most recently mounted monitor wins.
+ */
+export function useKeyMonitor(
+  monitor: MonitorCallback | undefined,
+  options: UseKeyMonitorOptions = {},
+): void {
+  const { event = "keydown" } = options;
+  const monitorRef = useLatest(monitor);
+  const hasMonitor = typeof monitor === "function";
+
+  useEffect(() => {
+    if (!hasMonitor) {
+      return;
+    }
+    const listener = getSharedListener(event);
+    if (!listener) {
+      return;
+    }
+    listener.setMonitor((info) => monitorRef.current?.(info));
+    return () => {
+      listener.setMonitor(false);
+    };
+  }, [event, hasMonitor, monitorRef]);
+}

--- a/packages/react-keyboardist/src/use-keyboard-layer.ts
+++ b/packages/react-keyboardist/src/use-keyboard-layer.ts
@@ -1,0 +1,97 @@
+import type { BindingMap, KeyboardEventName, Layer } from "keyboardist";
+import { useEffect, useId, useMemo, useRef } from "react";
+import { getSharedListener } from "./shared-listener";
+import { keySignatureOf } from "./use-key-bindings";
+import { useLatest } from "./use-latest";
+
+export interface UseKeyboardLayerOptions {
+  /** Layer name; auto-generated (collision-free) when omitted */
+  name?: string;
+  /** Unmatched keys go inert instead of falling through */
+  exclusive?: boolean;
+  /** Whether the layer is on the stack; defaults to true */
+  active?: boolean;
+  event?: KeyboardEventName;
+}
+
+export interface KeyboardLayerHandle {
+  isActive: () => boolean;
+  push: () => void;
+  pop: () => void;
+}
+
+/**
+ * Creates a keyboardist layer for the lifetime of the component, pushes it
+ * while `active` (default true), and disposes it on unmount.
+ */
+export function useKeyboardLayer(
+  bindings: BindingMap,
+  options: UseKeyboardLayerOptions = {},
+): KeyboardLayerHandle {
+  const { name, exclusive = false, active = true, event = "keydown" } = options;
+  const autoId = useId();
+  const layerName = name ?? `react:${autoId}`;
+
+  const bindingsRef = useLatest(bindings);
+  const keySignature = keySignatureOf(bindings);
+  const layerRef = useRef<Layer | null>(null);
+
+  // create the layer for this component's lifetime
+  useEffect(() => {
+    const listener = getSharedListener(event);
+    if (!listener) {
+      return;
+    }
+    const layer = listener.layer(layerName, undefined, { exclusive });
+    layerRef.current = layer;
+    return () => {
+      layer.dispose();
+      layerRef.current = null;
+    };
+  }, [event, layerName, exclusive]);
+
+  // keep the layer's bindings in sync with the current key set
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-runs after the layer is recreated (event/layerName/exclusive) or when the key set changes (keySignature); callbacks are read through bindingsRef
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer) {
+      return;
+    }
+    const subscriptions = Object.keys(bindingsRef.current).map((key) =>
+      layer.subscribe(key, (keyboardEvent) =>
+        bindingsRef.current[key]?.(keyboardEvent),
+      ),
+    );
+    return () => {
+      for (const subscription of subscriptions) {
+        subscription.unsubscribe();
+      }
+    };
+  }, [event, layerName, exclusive, keySignature, bindingsRef]);
+
+  // push/pop driven by `active`
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-pushes after the layer is recreated by the effect above
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer || !active) {
+      return;
+    }
+    layer.push();
+    return () => {
+      layer.pop();
+    };
+  }, [event, layerName, exclusive, active]);
+
+  return useMemo(
+    () => ({
+      isActive: () => layerRef.current?.isActive() ?? false,
+      push: () => {
+        layerRef.current?.push();
+      },
+      pop: () => {
+        layerRef.current?.pop();
+      },
+    }),
+    [],
+  );
+}

--- a/packages/react-keyboardist/src/use-latest.ts
+++ b/packages/react-keyboardist/src/use-latest.ts
@@ -1,0 +1,10 @@
+import { type RefObject, useRef } from "react";
+
+// Keeps a ref pointing at the latest value so stable subscription wrappers
+// always call the current callback — inline objects and closures from the
+// latest render just work, without resubscribing on every render.
+export function useLatest<T>(value: T): RefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}

--- a/packages/react-keyboardist/test/components.test.tsx
+++ b/packages/react-keyboardist/test/components.test.tsx
@@ -78,4 +78,24 @@ describe("<KeyboardInput>", () => {
     );
     expect(container.querySelector("textarea")).not.toBe(null);
   });
+
+  test("reattaches bindings when the rendered element changes", () => {
+    const onDown = vi.fn();
+    const { container, rerender } = render(
+      <KeyboardInput bindings={{ down: onDown }} component="input" />,
+    );
+    const input = container.querySelector("input");
+    expect(input).not.toBe(null);
+    fireEvent.keyDown(input as HTMLInputElement, { code: "ArrowDown" });
+    expect(onDown).toHaveBeenCalledTimes(1);
+
+    rerender(<KeyboardInput bindings={{ down: onDown }} component="textarea" />);
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBe(null);
+    fireEvent.keyDown(textarea as HTMLTextAreaElement, { code: "ArrowDown" });
+    expect(onDown).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(input as HTMLInputElement, { code: "ArrowDown" });
+    expect(onDown).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/react-keyboardist/test/components.test.tsx
+++ b/packages/react-keyboardist/test/components.test.tsx
@@ -89,7 +89,9 @@ describe("<KeyboardInput>", () => {
     fireEvent.keyDown(input as HTMLInputElement, { code: "ArrowDown" });
     expect(onDown).toHaveBeenCalledTimes(1);
 
-    rerender(<KeyboardInput bindings={{ down: onDown }} component="textarea" />);
+    rerender(
+      <KeyboardInput bindings={{ down: onDown }} component="textarea" />,
+    );
     const textarea = container.querySelector("textarea");
     expect(textarea).not.toBe(null);
     fireEvent.keyDown(textarea as HTMLTextAreaElement, { code: "ArrowDown" });

--- a/packages/react-keyboardist/test/components.test.tsx
+++ b/packages/react-keyboardist/test/components.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent } from "@testing-library/dom";
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, test, vi } from "vitest";
+import { KeyboardInput, Keyboardist, KeyboardLayer } from "../src/components";
+
+describe("<Keyboardist>", () => {
+  test("renders nothing and binds keys", () => {
+    const callback = vi.fn();
+    const { container, unmount } = render(
+      <Keyboardist bindings={{ KeyR: callback }} />,
+    );
+
+    expect(container.firstChild).toBe(null);
+    fireEvent.keyDown(document, { code: "KeyR" });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unmount();
+    fireEvent.keyDown(document, { code: "KeyR" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts a monitor", () => {
+    const monitor = vi.fn();
+    const { unmount } = render(<Keyboardist bindings={{}} monitor={monitor} />);
+
+    fireEvent.keyDown(document, { code: "KeyS" });
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(monitor.mock.calls[0]?.[0]).toMatchObject({ keyName: "s" });
+    unmount();
+  });
+});
+
+describe("<KeyboardLayer>", () => {
+  test("renders children and scopes the keyboard while mounted", () => {
+    const baseCallback = vi.fn();
+    const escapeCallback = vi.fn();
+    render(<Keyboardist bindings={{ KeyT: baseCallback }} />);
+
+    const { getByText, unmount } = render(
+      <KeyboardLayer bindings={{ escape: escapeCallback }} exclusive>
+        <div>modal content</div>
+      </KeyboardLayer>,
+    );
+
+    expect(getByText("modal content")).toBeDefined();
+
+    fireEvent.keyDown(document, { code: "KeyT" });
+    expect(baseCallback).not.toHaveBeenCalled();
+    fireEvent.keyDown(document, { code: "Escape" });
+    expect(escapeCallback).toHaveBeenCalledTimes(1);
+
+    unmount();
+    fireEvent.keyDown(document, { code: "KeyT" });
+    expect(baseCallback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("<KeyboardInput>", () => {
+  test("renders an input whose bindings fire while it has focus", () => {
+    const onDown = vi.fn();
+    const { getByRole } = render(<KeyboardInput bindings={{ down: onDown }} />);
+
+    const input = getByRole("textbox");
+    fireEvent.keyDown(input, { code: "ArrowDown" });
+    expect(onDown).toHaveBeenCalledTimes(1);
+  });
+
+  test("forwards its ref", () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<KeyboardInput bindings={{}} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  test("renders a custom component/tag", () => {
+    const { container } = render(
+      <KeyboardInput bindings={{}} component="textarea" />,
+    );
+    expect(container.querySelector("textarea")).not.toBe(null);
+  });
+});

--- a/packages/react-keyboardist/test/import.node.test.ts
+++ b/packages/react-keyboardist/test/import.node.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+// The RSC contract: this module must be importable in a server
+// environment (no window, no DOM) without throwing.
+import { describe, expect, test } from "vitest";
+import * as ReactKeyboardist from "../src/index";
+
+describe("server-side import safety", () => {
+  test("module imports without a DOM and exposes the API", () => {
+    expect(ReactKeyboardist.useKeyBindings).toBeTypeOf("function");
+    expect(ReactKeyboardist.useKeyboardLayer).toBeTypeOf("function");
+    expect(ReactKeyboardist.useKeyMonitor).toBeTypeOf("function");
+    expect(ReactKeyboardist.useElementKeyBindings).toBeTypeOf("function");
+    expect(ReactKeyboardist.Keyboardist).toBeTypeOf("function");
+    expect(ReactKeyboardist.KeyboardLayer).toBeTypeOf("function");
+    expect(ReactKeyboardist.KeyboardInput).toBeDefined();
+    expect(ReactKeyboardist.default).toBe(ReactKeyboardist.Keyboardist);
+  });
+});

--- a/packages/react-keyboardist/test/setup.ts
+++ b/packages/react-keyboardist/test/setup.ts
@@ -1,0 +1,6 @@
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/react-keyboardist/test/use-key-bindings.test.tsx
+++ b/packages/react-keyboardist/test/use-key-bindings.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent } from "@testing-library/dom";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useKeyBindings } from "../src/use-key-bindings";
+
+describe("useKeyBindings", () => {
+  test("bindings fire on keydown", () => {
+    const callback = vi.fn();
+    renderHook(() => useKeyBindings({ KeyA: callback }));
+
+    fireEvent.keyDown(document, { code: "KeyA" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("unmount unsubscribes", () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useKeyBindings({ KeyB: callback }));
+
+    unmount();
+    fireEvent.keyDown(document, { code: "KeyB" });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test("inline objects: rerender with a new object neither drops nor duplicates", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      // a fresh object every render, like inline JSX props
+      ({ cb }) => useKeyBindings({ KeyC: cb }),
+      { initialProps: { cb: callback } },
+    );
+
+    rerender({ cb: callback });
+    rerender({ cb: callback });
+
+    fireEvent.keyDown(document, { code: "KeyC" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("the latest callback is used after rerender", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ cb }) => useKeyBindings({ KeyD: cb }), {
+      initialProps: { cb: first },
+    });
+
+    rerender({ cb: second });
+    fireEvent.keyDown(document, { code: "KeyD" });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test("changing the key set rebinds", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(({ keys }) => useKeyBindings(keys), {
+      initialProps: { keys: { KeyE: callback } as Record<string, () => void> },
+    });
+
+    rerender({ keys: { KeyF: callback } });
+
+    fireEvent.keyDown(document, { code: "KeyE" });
+    expect(callback).not.toHaveBeenCalled();
+    fireEvent.keyDown(document, { code: "KeyF" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("comma aliases bind several keys", () => {
+    const callback = vi.fn();
+    renderHook(() => useKeyBindings({ "KeyG,KeyH": callback }));
+
+    fireEvent.keyDown(document, { code: "KeyG" });
+    fireEvent.keyDown(document, { code: "KeyH" });
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-keyboardist/test/use-key-monitor.test.tsx
+++ b/packages/react-keyboardist/test/use-key-monitor.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent } from "@testing-library/dom";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useKeyMonitor } from "../src/use-key-monitor";
+
+describe("useKeyMonitor", () => {
+  test("receives structured monitor info", () => {
+    const monitor = vi.fn();
+    const { unmount } = renderHook(() => useKeyMonitor(monitor));
+
+    fireEvent.keyDown(document, { code: "KeyU", shiftKey: true });
+
+    expect(monitor).toHaveBeenCalledTimes(1);
+    expect(monitor.mock.calls[0]?.[0]).toMatchObject({
+      keyName: "shift+u",
+      matched: expect.any(Boolean),
+    });
+    unmount();
+  });
+
+  test("cleans up on unmount", () => {
+    const monitor = vi.fn();
+    const { unmount } = renderHook(() => useKeyMonitor(monitor));
+
+    unmount();
+    fireEvent.keyDown(document, { code: "KeyV" });
+    expect(monitor).not.toHaveBeenCalled();
+  });
+
+  test("the latest monitor function is used after rerender", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender, unmount } = renderHook(({ fn }) => useKeyMonitor(fn), {
+      initialProps: { fn: first },
+    });
+
+    rerender({ fn: second });
+    fireEvent.keyDown(document, { code: "KeyW" });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});

--- a/packages/react-keyboardist/test/use-key-monitor.test.tsx
+++ b/packages/react-keyboardist/test/use-key-monitor.test.tsx
@@ -40,4 +40,18 @@ describe("useKeyMonitor", () => {
     expect(second).toHaveBeenCalledTimes(1);
     unmount();
   });
+
+  test("unmounting an older monitor does not clear a newer one", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const firstHook = renderHook(() => useKeyMonitor(first));
+    const secondHook = renderHook(() => useKeyMonitor(second));
+
+    firstHook.unmount();
+    fireEvent.keyDown(document, { code: "KeyY" });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    secondHook.unmount();
+  });
 });

--- a/packages/react-keyboardist/test/use-keyboard-layer.test.tsx
+++ b/packages/react-keyboardist/test/use-keyboard-layer.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent } from "@testing-library/dom";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useKeyBindings } from "../src/use-key-bindings";
+import { useKeyboardLayer } from "../src/use-keyboard-layer";
+
+describe("useKeyboardLayer", () => {
+  test("layer bindings fire while mounted and active", () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useKeyboardLayer({ KeyI: callback }));
+
+    fireEvent.keyDown(document, { code: "KeyI" });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unmount();
+    fireEvent.keyDown(document, { code: "KeyI" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("active: false keeps the layer off the stack", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ active }) => useKeyboardLayer({ KeyJ: callback }, { active }),
+      { initialProps: { active: false } },
+    );
+
+    fireEvent.keyDown(document, { code: "KeyJ" });
+    expect(callback).not.toHaveBeenCalled();
+
+    rerender({ active: true });
+    fireEvent.keyDown(document, { code: "KeyJ" });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender({ active: false });
+    fireEvent.keyDown(document, { code: "KeyJ" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("exclusive layer swallows keys bound below it", () => {
+    const baseCallback = vi.fn();
+    const { unmount: unmountBase } = renderHook(() =>
+      useKeyBindings({ KeyK: baseCallback }),
+    );
+    const { unmount: unmountLayer } = renderHook(() =>
+      useKeyboardLayer({ KeyL: vi.fn() }, { exclusive: true }),
+    );
+
+    fireEvent.keyDown(document, { code: "KeyK" });
+    expect(baseCallback).not.toHaveBeenCalled();
+
+    unmountLayer();
+    fireEvent.keyDown(document, { code: "KeyK" });
+    expect(baseCallback).toHaveBeenCalledTimes(1);
+    unmountBase();
+  });
+
+  test("two instances with auto names don't collide", () => {
+    const one = vi.fn();
+    const two = vi.fn();
+    renderHook(() => useKeyboardLayer({ KeyO: one }));
+    renderHook(() => useKeyboardLayer({ KeyP: two }));
+
+    fireEvent.keyDown(document, { code: "KeyO" });
+    fireEvent.keyDown(document, { code: "KeyP" });
+    expect(one).toHaveBeenCalledTimes(1);
+    expect(two).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns a working handle", () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() =>
+      useKeyboardLayer({ KeyQ: callback }, { active: false }),
+    );
+
+    expect(result.current.isActive()).toBe(false);
+    result.current.push();
+    expect(result.current.isActive()).toBe(true);
+    fireEvent.keyDown(document, { code: "KeyQ" });
+    expect(callback).toHaveBeenCalledTimes(1);
+    result.current.pop();
+    expect(result.current.isActive()).toBe(false);
+  });
+});

--- a/packages/react-keyboardist/tsconfig.build.json
+++ b/packages/react-keyboardist/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // No paths override here: the dts build must treat `keyboardist` as an
+    // external package (its published types), not follow the source mapping —
+    // otherwise tsc emits stray .d.ts files into ../keyboardist/src.
+    "paths": {}
+  },
+  "include": ["src"]
+}

--- a/packages/react-keyboardist/tsconfig.json
+++ b/packages/react-keyboardist/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "paths": {
+      "keyboardist": ["../keyboardist/src/index.ts"]
+    }
+  },
+  "include": ["src", "test", "tsdown.config.ts", "vitest.config.ts"]
+}

--- a/packages/react-keyboardist/tsdown.config.ts
+++ b/packages/react-keyboardist/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  platform: "browser",
+  tsconfig: "tsconfig.build.json",
+  dts: true,
+  sourcemap: true,
+});

--- a/packages/react-keyboardist/vitest.config.ts
+++ b/packages/react-keyboardist/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Test against keyboardist source so no build step is needed.
+      keyboardist: fileURLToPath(
+        new URL("../keyboardist/src/index.ts", import.meta.url),
+      ),
+    },
+  },
+  test: {
+    environment: "happy-dom",
+    setupFiles: ["./test/setup.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,25 @@ importers:
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+      react-keyboardist:
+        specifier: workspace:^
+        version: link:../../packages/react-keyboardist
     devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@26.1.1))
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -51,6 +69,46 @@ importers:
       publint:
         specifier: ^0.3.21
         version: 0.3.21
+      tsdown:
+        specifier: ^0.22.13
+        version: 0.22.13(@arethetypeswrong/core@0.18.5)(publint@0.3.21)(typescript@7.0.2)
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@26.1.1)(happy-dom@20.11.1)(vite@8.1.5(@types/node@26.1.1))
+
+  packages/react-keyboardist:
+    dependencies:
+      keyboardist:
+        specifier: workspace:^
+        version: link:../keyboardist
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.5
+        version: 0.18.5
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      happy-dom:
+        specifier: ^20.11.1
+        version: 20.11.1
+      publint:
+        specifier: ^0.3.21
+        version: 0.3.21
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       tsdown:
         specifier: ^0.22.13
         version: 0.22.13(@arethetypeswrong/core@0.18.5)(publint@0.3.21)(typescript@7.0.2)
@@ -467,6 +525,21 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
@@ -487,6 +560,14 @@ packages:
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
@@ -613,6 +694,19 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@vitejs/plugin-react@6.0.4':
+    resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -871,6 +965,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
@@ -1323,8 +1420,17 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1383,6 +1489,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -2137,6 +2246,16 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -2158,6 +2277,14 @@ snapshots:
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/whatwg-mimetype@3.0.2': {}
 
@@ -2224,6 +2351,11 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
+
+  '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@26.1.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@26.1.1)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2433,6 +2565,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  csstype@3.2.3: {}
 
   dataloader@1.4.0: {}
 
@@ -2793,7 +2927,14 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
   react-is@17.0.2: {}
+
+  react@19.2.8: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -2875,6 +3016,8 @@ snapshots:
       mri: 1.2.0
 
   safer-buffer@2.1.2: {}
+
+  scheduler@0.27.0: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
## What does this PR do?

Folds **react-keyboardist** into the monorepo as `packages/react-keyboardist`, rewritten from scratch for React 18/19 and React Server Components. Stacked on #49 (which stacks on #48) — merge order: #48 → #49 → this.

The [old repo](https://github.com/soska/react-keyboardist) (last commit 2020: Flow, class components, keyboardist 1.x, module-scope listeners) supplied the API shape; none of the code survived. Developed TDD — 21 tests written first.

### Hooks
```jsx
useKeyBindings({ "cmd+k": openPalette, "j,k": step });
useKeyboardLayer({ escape: close }, { exclusive: true });  // scoped to the component
useKeyMonitor(({ keyName, matched, layer }) => ...);
useElementKeyBindings(inputRef, { up: next, down: prev });
```
Inline bindings objects are safe: callbacks are read through refs; resubscription happens only when the key set changes.

### Components
`<Keyboardist bindings monitor?>` (the classic API, still the default export), `<KeyboardLayer bindings exclusive? active?>` wrapping children, `<KeyboardInput>` with ref forwarding.

### RSC / Next.js
- Published bundle starts with `"use client"` (preserved by tsdown; asserted in `check:publish`) — components drop straight into server-component trees
- Listeners are lazy singletons created in effects, never at module scope; a node-environment test guards the no-DOM import contract

### Release plumbing
- Changesets **fixed group**: `keyboardist` + `react-keyboardist` now version in lockstep — both ship as **3.0.0**
- Website gains a React island: `useKeyBindings` counter, an exclusive `<KeyboardLayer>` modal, and `useKeyMonitor` feeding the same on-screen monitor as the vanilla demos — one shared listener across both worlds

## Checklist

- [x] Tests added or updated (features and fixes are developed test-first)
- [x] `pnpm check` passes locally
- [x] A changeset is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)