### PR TITLE
Nesting-aware layer priority: inner layers win, as the JSX says

### DIFF
--- a/.changeset/layer-priority.md
+++ b/.changeset/layer-priority.md
@@ -1,0 +1,9 @@
+---
+"keyboardist": minor
+"react-keyboardist": minor
+---
+
+Nesting-aware layer priority.
+
+- **keyboardist**: `LayerOptions` gains `priority` (default `0`). Higher-priority layers always sit above lower-priority ones regardless of push order; within a priority, the latest push stays on top (existing behavior unchanged). `Layer.priority` and `getBindings()` expose it.
+- **react-keyboardist**: layer priority is now derived from the component tree — nested `<KeyboardLayer>`s (and `<KeyboardScope>`, new, for hook-only composition) win overlapping keys from the inside out, even when the whole tree mounts in one commit. This fixes the inversion where React's child-first effect order put the *outermost* layer on top on initial renders and deep links. Works through portals; an explicit `priority` prop/option overrides the derived depth.

--- a/packages/keyboardist/README.md
+++ b/packages/keyboardist/README.md
@@ -182,6 +182,25 @@ leaves the upper one exactly where it is. Re-pushing an active layer moves it
 to the top. Layers also have `subscribe(key, fn)`, `bind(map)` (returns one
 subscription for the whole map), `pop()`, `isActive()`, and `dispose()`.
 
+### Priority
+
+When push order can't express who should win — for example when a framework
+schedules your pushes in an order you don't control — give layers a
+`priority` (default `0`). Higher-priority layers always sit above
+lower-priority ones regardless of push order; within the same priority, the
+latest push is on top, exactly like before:
+
+```javascript
+kb.layer("layout", { escape: closeSidebar }, { priority: 1 });
+kb.layer("modal", { escape: closeModal }, { priority: 3 });
+
+// no matter which order these get pushed in, modal beats layout
+```
+
+(If you use [react-keyboardist](https://www.npmjs.com/package/react-keyboardist),
+priority is derived from the component tree automatically — you shouldn't
+need to set it by hand.)
+
 Inspect the stack at runtime with `kb.activeLayers()` (names, top to bottom,
 ending in `"base"`) and `kb.getBindings()` (every binding with its layer and
 active state).

--- a/packages/keyboardist/src/layer.ts
+++ b/packages/keyboardist/src/layer.ts
@@ -16,6 +16,14 @@ export interface LayerOptions {
    * through to the layers below it — they simply go inert.
    */
   exclusive?: boolean;
+  /**
+   * Stack rank (default 0). Higher-priority layers always sit above
+   * lower-priority ones regardless of push order; within the same
+   * priority, the latest push is on top. Lets callers whose push order
+   * doesn't match their logical nesting (e.g. React effects running
+   * child-first) still get the stack they mean.
+   */
+  priority?: number;
 }
 
 export interface PopHandle {
@@ -26,6 +34,7 @@ export interface PopHandle {
 export interface Layer {
   readonly name: string;
   readonly exclusive: boolean;
+  readonly priority: number;
   subscribe: (name: string, callback: SubscriptionCallback) => Subscription;
   bind: (bindings: BindingMap) => Subscription;
   push: () => PopHandle;
@@ -38,6 +47,7 @@ export interface BindingInfo {
   layer: string;
   key: string;
   active: boolean;
+  priority: number;
 }
 
 export type MatchResult =
@@ -48,6 +58,7 @@ export type MatchResult =
 interface LayerState {
   name: string;
   exclusive: boolean;
+  priority: number;
   subscriptions: Map<string, SubscriptionCallback[]>;
 }
 
@@ -82,6 +93,7 @@ export class LayerStack {
     const state: LayerState = {
       name,
       exclusive: options?.exclusive ?? false,
+      priority: options?.priority ?? 0,
       subscriptions: new Map(),
     };
     this.states.set(name, state);
@@ -130,8 +142,18 @@ export class LayerStack {
     };
 
     const push = (): PopHandle => {
-      pop(); // re-pushing an active layer moves it to the top
-      this.stack.push(state);
+      pop(); // re-pushing an active layer re-inserts it by the same rule
+      // Insert below any higher-priority layers, on top of the layer's own
+      // priority band (equal priority stays LIFO). Index 0 is the base
+      // layer, which nothing may go below.
+      let index = this.stack.length;
+      while (
+        index > 1 &&
+        (this.stack[index - 1] as LayerState).priority > state.priority
+      ) {
+        index--;
+      }
+      this.stack.splice(index, 0, state);
       const handle = (() => {
         pop();
       }) as PopHandle;
@@ -144,6 +166,7 @@ export class LayerStack {
     const layer: Layer = {
       name,
       exclusive: state.exclusive,
+      priority: state.priority,
       subscribe,
       bind,
       push,
@@ -195,7 +218,12 @@ export class LayerStack {
       const active = this.stack.includes(state);
       for (const [key, listeners] of state.subscriptions) {
         if (listeners.length > 0) {
-          bindings.push({ layer: state.name, key, active });
+          bindings.push({
+            layer: state.name,
+            key,
+            active,
+            priority: state.priority,
+          });
         }
       }
     }

--- a/packages/keyboardist/test/layers.test.ts
+++ b/packages/keyboardist/test/layers.test.ts
@@ -230,3 +230,127 @@ describe("map registration", () => {
     expect(two).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("layer priority", () => {
+  test("a higher-priority layer stays above a later plain push", () => {
+    const kb = createListenerOrThrow();
+    const modalCallback = vi.fn();
+    const layoutCallback = vi.fn();
+    const modal = kb.layer(
+      "prio-modal",
+      { Digit1: modalCallback },
+      { priority: 3 },
+    );
+    const layout = kb.layer(
+      "prio-layout",
+      { Digit1: layoutCallback },
+      { priority: 1 },
+    );
+
+    // pushed in "wrong" (React child-first) order: modal first, layout last
+    modal.push();
+    layout.push();
+
+    fireEvent.keyDown(document, { code: "Digit1" });
+    expect(modalCallback).toHaveBeenCalledTimes(1);
+    expect(layoutCallback).not.toHaveBeenCalled();
+  });
+
+  test("equal priority keeps LIFO: later push wins", () => {
+    const kb = createListenerOrThrow();
+    const first = vi.fn();
+    const second = vi.fn();
+    kb.layer("prio-eq-a", { Digit2: first }, { priority: 2 }).push();
+    kb.layer("prio-eq-b", { Digit2: second }, { priority: 2 }).push();
+
+    fireEvent.keyDown(document, { code: "Digit2" });
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  test("three layers pushed in reverse priority order sort correctly", () => {
+    const kb = createListenerOrThrow();
+    const kb3 = vi.fn();
+    const kb2 = vi.fn();
+    const kb1 = vi.fn();
+    kb.layer("prio-r3", { Digit3: kb3 }, { priority: 3 }).push();
+    kb.layer("prio-r2", { Digit3: kb2 }, { priority: 2 }).push();
+    kb.layer("prio-r1", { Digit3: kb1 }, { priority: 1 }).push();
+
+    expect(kb.activeLayers()).toEqual([
+      "prio-r3",
+      "prio-r2",
+      "prio-r1",
+      "base",
+    ]);
+    fireEvent.keyDown(document, { code: "Digit3" });
+    expect(kb3).toHaveBeenCalledTimes(1);
+    expect(kb2).not.toHaveBeenCalled();
+    expect(kb1).not.toHaveBeenCalled();
+  });
+
+  test("re-push moves to the top of its own priority band only", () => {
+    const kb = createListenerOrThrow();
+    const low = kb.layer("prio-band-low", {}, { priority: 1 });
+    const lowLater = kb.layer("prio-band-low2", {}, { priority: 1 });
+    const high = kb.layer("prio-band-high", {}, { priority: 5 });
+
+    low.push();
+    lowLater.push();
+    high.push();
+    low.push(); // re-push: tops its band, stays below high
+
+    expect(kb.activeLayers()).toEqual([
+      "prio-band-high",
+      "prio-band-low",
+      "prio-band-low2",
+      "base",
+    ]);
+  });
+
+  test("base layer stays at the bottom below priority-0 layers", () => {
+    const kb = createListenerOrThrow();
+    const baseCallback = vi.fn();
+    const layerCallback = vi.fn();
+    kb.subscribe("Digit4", baseCallback);
+    kb.layer("prio-zero", { Digit4: layerCallback }).push();
+
+    fireEvent.keyDown(document, { code: "Digit4" });
+    expect(layerCallback).toHaveBeenCalledTimes(1);
+    expect(baseCallback).not.toHaveBeenCalled();
+    expect(kb.activeLayers()).toEqual(["prio-zero", "base"]);
+  });
+
+  test("a high-priority exclusive layer swallows keys below regardless of push order", () => {
+    const kb = createListenerOrThrow();
+    const layoutCallback = vi.fn();
+    const modal = kb.layer(
+      "prio-excl-modal",
+      {},
+      { priority: 9, exclusive: true },
+    );
+    const layout = kb.layer(
+      "prio-excl-layout",
+      { Digit5: layoutCallback },
+      { priority: 1 },
+    );
+
+    modal.push();
+    layout.push(); // pushed after, but lower priority: stays below the exclusive modal
+
+    fireEvent.keyDown(document, { code: "Digit5" });
+    expect(layoutCallback).not.toHaveBeenCalled();
+  });
+
+  test("getBindings reports priority", () => {
+    const kb = createListenerOrThrow();
+    kb.layer("prio-bindings", { Digit6: vi.fn() }, { priority: 7 });
+
+    expect(kb.getBindings()).toContainEqual({
+      layer: "prio-bindings",
+      key: "6",
+      active: false,
+      priority: 7,
+    });
+  });
+});

--- a/packages/keyboardist/test/monitor.test.ts
+++ b/packages/keyboardist/test/monitor.test.ts
@@ -112,11 +112,13 @@ describe("introspection", () => {
       layer: "base",
       key: "backslash",
       active: true,
+      priority: 0,
     });
     expect(kb.getBindings()).toContainEqual({
       layer: "intro-bindings",
       key: "shift+backslash",
       active: false,
+      priority: 0,
     });
 
     layer.push();
@@ -124,6 +126,7 @@ describe("introspection", () => {
       layer: "intro-bindings",
       key: "shift+backslash",
       active: true,
+      priority: 0,
     });
   });
 });

--- a/packages/react-keyboardist/README.md
+++ b/packages/react-keyboardist/README.md
@@ -68,6 +68,30 @@ function SearchModal({ onClose }) {
 Also returns a handle: `const layer = useKeyboardLayer(...)` →
 `layer.isActive()`, `layer.push()`, `layer.pop()`.
 
+### Nesting is priority
+
+When layers overlap on the same key, **the innermost component wins** —
+the JSX nesting is the priority:
+
+```jsx
+<DashboardLayout>            {/* KeyboardLayer: escape → close sidebar */}
+  <Posts>                    {/* KeyboardLayer: escape → clear selection */}
+    <EditPostModal />        {/* KeyboardLayer: escape → close modal ← wins */}
+  </Posts>
+</DashboardLayout>
+```
+
+This holds even when the whole tree mounts in a single commit. (React runs
+effects child-first, so without this the *outermost* layer would land on top
+of the stack — an inversion that only shows up on initial renders and deep
+links.) Priority is derived from `<KeyboardLayer>` nesting via context, so
+it also flows through portals: a modal rendered with `createPortal` keeps
+the priority of its place in the JSX tree, not the DOM.
+
+Hook-only users can add a nesting level without creating a layer using
+`<KeyboardScope>`; and an explicit `priority` prop/option overrides the
+derived depth for the rare cross-tree case.
+
 ### useKeyMonitor
 
 Observe every key event (one monitor slot per listener — last mounted wins):

--- a/packages/react-keyboardist/package.json
+++ b/packages/react-keyboardist/package.json
@@ -56,6 +56,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "happy-dom": "^20.11.1",
     "publint": "^0.3.21",
     "react": "^19.2.8",

--- a/packages/react-keyboardist/src/components.tsx
+++ b/packages/react-keyboardist/src/components.tsx
@@ -8,8 +8,10 @@ import {
   type ElementType,
   forwardRef,
   type ReactNode,
+  useContext,
   useRef,
 } from "react";
+import { KeyboardDepthContext } from "./depth-context";
 import { useElementKeyBindings } from "./use-element-key-bindings";
 import { useKeyBindings } from "./use-key-bindings";
 import { useKeyMonitor } from "./use-key-monitor";
@@ -35,6 +37,8 @@ export interface KeyboardLayerProps {
   name?: string;
   exclusive?: boolean;
   active?: boolean;
+  /** Overrides the depth-derived stack priority */
+  priority?: number;
   event?: KeyboardEventName;
   children?: ReactNode;
 }
@@ -42,17 +46,42 @@ export interface KeyboardLayerProps {
 /**
  * Scopes the keyboard to its bindings while mounted (and `active`). Wrap a
  * modal in an exclusive layer and it owns the keyboard until it unmounts.
+ *
+ * Nested KeyboardLayers derive their stack priority from the JSX nesting:
+ * inner layers win overlapping keys, even when the whole tree mounts in a
+ * single commit (where React's child-first effect order would otherwise
+ * put the outermost layer on top).
  */
 export function KeyboardLayer({
   bindings,
   name,
   exclusive,
   active,
+  priority,
   event,
   children,
 }: KeyboardLayerProps) {
-  useKeyboardLayer(bindings, { name, exclusive, active, event });
-  return <>{children}</>;
+  const depth = useContext(KeyboardDepthContext);
+  useKeyboardLayer(bindings, { name, exclusive, active, priority, event });
+  return (
+    <KeyboardDepthContext.Provider value={depth + 1}>
+      {children}
+    </KeyboardDepthContext.Provider>
+  );
+}
+
+/**
+ * Increments the keyboard nesting depth for its children without creating
+ * a layer of its own — for hook-only users composing useKeyboardLayer
+ * across components. <KeyboardLayer> provides this automatically.
+ */
+export function KeyboardScope({ children }: { children?: ReactNode }) {
+  const depth = useContext(KeyboardDepthContext);
+  return (
+    <KeyboardDepthContext.Provider value={depth + 1}>
+      {children}
+    </KeyboardDepthContext.Provider>
+  );
 }
 
 export type KeyboardInputProps = {

--- a/packages/react-keyboardist/src/depth-context.ts
+++ b/packages/react-keyboardist/src/depth-context.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+// Tracks how deep in the component tree a layer sits. Layer priority is
+// derived from this depth, so the JSX nesting — not React's child-first
+// effect order — decides which layer wins overlapping keys. Flows through
+// portals, so a portaled modal keeps its logical nesting priority.
+export const KeyboardDepthContext = createContext(0);

--- a/packages/react-keyboardist/src/index.ts
+++ b/packages/react-keyboardist/src/index.ts
@@ -19,6 +19,7 @@ export {
   type KeyboardistProps,
   KeyboardLayer,
   type KeyboardLayerProps,
+  KeyboardScope,
 } from "./components";
 export { getSharedListener } from "./shared-listener";
 export {

--- a/packages/react-keyboardist/src/use-keyboard-layer.ts
+++ b/packages/react-keyboardist/src/use-keyboard-layer.ts
@@ -1,5 +1,6 @@
 import type { BindingMap, KeyboardEventName, Layer } from "keyboardist";
-import { useEffect, useId, useMemo, useRef } from "react";
+import { useContext, useEffect, useId, useMemo, useRef } from "react";
+import { KeyboardDepthContext } from "./depth-context";
 import { getSharedListener } from "./shared-listener";
 import { keySignatureOf } from "./use-key-bindings";
 import { useLatest } from "./use-latest";
@@ -11,6 +12,13 @@ export interface UseKeyboardLayerOptions {
   exclusive?: boolean;
   /** Whether the layer is on the stack; defaults to true */
   active?: boolean;
+  /**
+   * Stack priority. Defaults to the component's depth in the tree (via
+   * <KeyboardLayer>/<KeyboardScope> nesting), so inner layers win
+   * overlapping keys regardless of React's child-first effect order.
+   * Set explicitly to override the derived depth.
+   */
+  priority?: number;
   event?: KeyboardEventName;
 }
 
@@ -31,6 +39,8 @@ export function useKeyboardLayer(
   const { name, exclusive = false, active = true, event = "keydown" } = options;
   const autoId = useId();
   const layerName = name ?? `react:${autoId}`;
+  const depth = useContext(KeyboardDepthContext);
+  const priority = options.priority ?? depth + 1;
 
   const bindingsRef = useLatest(bindings);
   const keySignature = keySignatureOf(bindings);
@@ -42,13 +52,13 @@ export function useKeyboardLayer(
     if (!listener) {
       return;
     }
-    const layer = listener.layer(layerName, undefined, { exclusive });
+    const layer = listener.layer(layerName, undefined, { exclusive, priority });
     layerRef.current = layer;
     return () => {
       layer.dispose();
       layerRef.current = null;
     };
-  }, [event, layerName, exclusive]);
+  }, [event, layerName, exclusive, priority]);
 
   // keep the layer's bindings in sync with the current key set
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-runs after the layer is recreated (event/layerName/exclusive) or when the key set changes (keySignature); callbacks are read through bindingsRef
@@ -67,7 +77,7 @@ export function useKeyboardLayer(
         subscription.unsubscribe();
       }
     };
-  }, [event, layerName, exclusive, keySignature, bindingsRef]);
+  }, [event, layerName, exclusive, priority, keySignature, bindingsRef]);
 
   // push/pop driven by `active`
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-pushes after the layer is recreated by the effect above
@@ -80,7 +90,7 @@ export function useKeyboardLayer(
     return () => {
       layer.pop();
     };
-  }, [event, layerName, exclusive, active]);
+  }, [event, layerName, exclusive, priority, active]);
 
   return useMemo(
     () => ({

--- a/packages/react-keyboardist/test/nesting.test.tsx
+++ b/packages/react-keyboardist/test/nesting.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent } from "@testing-library/dom";
+import { render } from "@testing-library/react";
+import { createPortal } from "react-dom";
+import { describe, expect, test, vi } from "vitest";
+import { KeyboardLayer, KeyboardScope } from "../src/components";
+import { useKeyboardLayer } from "../src/use-keyboard-layer";
+
+describe("nesting = priority", () => {
+  test("the headline regression: nested layers mounted in one commit — innermost wins", () => {
+    // <DashboardLayout><Posts><EditPostModal/></Posts></DashboardLayout>
+    // React runs effects child-first, so the modal PUSHES FIRST and the
+    // layout last — without depth-derived priority the layout would win.
+    const layoutEscape = vi.fn();
+    const postsEscape = vi.fn();
+    const modalEscape = vi.fn();
+
+    const { unmount } = render(
+      <KeyboardLayer name="dashboard" bindings={{ escape: layoutEscape }}>
+        <KeyboardLayer name="posts" bindings={{ escape: postsEscape }}>
+          <KeyboardLayer name="edit-modal" bindings={{ escape: modalEscape }} />
+        </KeyboardLayer>
+      </KeyboardLayer>,
+    );
+
+    fireEvent.keyDown(document, { code: "Escape" });
+    expect(modalEscape).toHaveBeenCalledTimes(1);
+    expect(postsEscape).not.toHaveBeenCalled();
+    expect(layoutEscape).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test("outer layer wins again after the inner one unmounts", () => {
+    const outerCallback = vi.fn();
+    const innerCallback = vi.fn();
+
+    function Tree({ showInner }: { showInner: boolean }) {
+      return (
+        <KeyboardLayer name="nest-outer" bindings={{ KeyZ: outerCallback }}>
+          {showInner && (
+            <KeyboardLayer
+              name="nest-inner"
+              bindings={{ KeyZ: innerCallback }}
+            />
+          )}
+        </KeyboardLayer>
+      );
+    }
+
+    const { rerender, unmount } = render(<Tree showInner={true} />);
+    fireEvent.keyDown(document, { code: "KeyZ" });
+    expect(innerCallback).toHaveBeenCalledTimes(1);
+    expect(outerCallback).not.toHaveBeenCalled();
+
+    rerender(<Tree showInner={false} />);
+    fireEvent.keyDown(document, { code: "KeyZ" });
+    expect(outerCallback).toHaveBeenCalledTimes(1);
+    expect(innerCallback).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  test("siblings at the same depth: later mount wins", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const { unmount: unmountFirst } = render(
+      <KeyboardLayer name="sib-a" bindings={{ Digit0: first }} />,
+    );
+    const { unmount: unmountSecond } = render(
+      <KeyboardLayer name="sib-b" bindings={{ Digit0: second }} />,
+    );
+
+    fireEvent.keyDown(document, { code: "Digit0" });
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+    unmountSecond();
+    unmountFirst();
+  });
+
+  test("explicit priority prop overrides derived depth", () => {
+    const outerCallback = vi.fn();
+    const innerCallback = vi.fn();
+
+    const { unmount } = render(
+      <KeyboardLayer
+        name="override-outer"
+        bindings={{ KeyX: outerCallback }}
+        priority={50}
+      >
+        <KeyboardLayer
+          name="override-inner"
+          bindings={{ KeyX: innerCallback }}
+        />
+      </KeyboardLayer>,
+    );
+
+    fireEvent.keyDown(document, { code: "KeyX" });
+    expect(outerCallback).toHaveBeenCalledTimes(1);
+    expect(innerCallback).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test("KeyboardScope increments depth for hook-only users", () => {
+    const shallowCallback = vi.fn();
+    const deepCallback = vi.fn();
+
+    function ShallowLayer() {
+      useKeyboardLayer({ KeyV: shallowCallback }, { name: "scope-shallow" });
+      return null;
+    }
+    function DeepLayer() {
+      useKeyboardLayer({ KeyV: deepCallback }, { name: "scope-deep" });
+      return null;
+    }
+
+    // Deep layer mounts FIRST in effect order (deeper in tree), shallow
+    // second — depth from KeyboardScope must still make the deep one win.
+    const { unmount } = render(
+      <>
+        <KeyboardScope>
+          <KeyboardScope>
+            <DeepLayer />
+          </KeyboardScope>
+        </KeyboardScope>
+        <ShallowLayer />
+      </>,
+    );
+
+    fireEvent.keyDown(document, { code: "KeyV" });
+    expect(deepCallback).toHaveBeenCalledTimes(1);
+    expect(shallowCallback).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test("portal-rendered modals keep their logical nesting priority", () => {
+    const layoutCallback = vi.fn();
+    const modalCallback = vi.fn();
+
+    function PortaledModal() {
+      return createPortal(
+        <KeyboardLayer name="portal-modal" bindings={{ KeyB: modalCallback }}>
+          <div>portal modal</div>
+        </KeyboardLayer>,
+        document.body,
+      );
+    }
+
+    const { unmount } = render(
+      <KeyboardLayer name="portal-layout" bindings={{ KeyB: layoutCallback }}>
+        <PortaledModal />
+      </KeyboardLayer>,
+    );
+
+    fireEvent.keyDown(document, { code: "KeyB" });
+    expect(modalCallback).toHaveBeenCalledTimes(1);
+    expect(layoutCallback).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       happy-dom:
         specifier: ^20.11.1
         version: 20.11.1


### PR DESCRIPTION
## What does this PR do?

Fixes a real-world inversion before 3.0.0 ships. In a tree like:

```jsx
<DashboardLayout>      {/* escape → close sidebar */}
  <Posts>              {/* escape → clear selection */}
    <EditPostModal />  {/* escape → close modal — should win */}
  </Posts>
</DashboardLayout>
```

React runs effects **child-first within a commit**, so when this tree mounts at once (initial render, deep link, route change) the modal pushes its layer *first* and the layout *last* — the outermost layer lands on top of the stack, backwards from the nesting. When a modal mounts later on user action, recency happens to be right — which is why the bug is intermittent and nasty.

### The fix: the JSX nesting *is* the priority

- **keyboardist**: `LayerOptions.priority` (default 0). Push inserts below higher-priority layers, on top of its own priority band; equal priority stays LIFO — nobody not using the option sees any change. Exposed on `Layer` and in `getBindings()`.
- **react-keyboardist**: priority is **derived from the component tree** via context — `<KeyboardLayer>` increments depth for its children (new `<KeyboardScope>` does the same for hook-only composition). Nobody writes a z-index; the tree is the z-index. An explicit `priority` prop remains as the escape hatch.
- Bonus property: context follows the JSX tree through **portals**, so a `createPortal` modal keeps its logical nesting priority (tested).

### TDD

13 new tests (7 core priority, 6 nesting), suites now 67 + 29. The headline regression test is the exact `DashboardLayout > Posts > EditPostModal` same-commit mount; verified it **fails against the previous insertion rule** and passes with this one.

Targets `modernize` so 3.0.0 ships with correct semantics from day one.

## Checklist

- [x] Tests added or updated (features and fixes are developed test-first)
- [x] `pnpm check` passes locally
- [x] A changeset is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)