### PR TITLE
Self-documenting bindings: subscribe() takes a description

### DIFF
--- a/.changeset/binding-descriptions.md
+++ b/.changeset/binding-descriptions.md
@@ -1,0 +1,12 @@
+---
+"keyboardist": minor
+---
+
+Self-documenting bindings.
+
+- **core**: `subscribe()` takes an optional third argument describing the binding — either an options object (`{ description, hidden }`) or a bare string as shorthand for `{ description }`. `getBindings()` returns the `description` alongside the existing `layer`/`key`/`active`/`priority`, so a UI can generate its own shortcut sheet from the live bindings. `hidden: true` keeps a binding out of that listing while leaving it fully functional.
+- **core**: `BindingMap` values accept an object form — `{ handler, description, hidden }` — anywhere a bare callback works today (`layer()`, `bind()`, and the React bindings props). Bare callbacks are unchanged.
+- **`keyboardist/react`**: descriptions flow through `useKeyBindings`, `useKeyboardLayer`, `useElementKeyBindings`, and the components that wrap them. Editing a description now resubscribes correctly — previously the dependency signature only tracked the key set, so a changed description would have gone stale.
+- Where one key has several subscriptions in a layer, the last one subscribed wins per field — it is also the first to run, so it is the one the user actually gets. Unsubscribing it falls back to the description beneath.
+
+Descriptions are purely additive: every existing call signature keeps working.

--- a/apps/website/src/demos/descriptions-demo.tsx
+++ b/apps/website/src/demos/descriptions-demo.tsx
@@ -1,0 +1,110 @@
+import {
+  type BindingInfo,
+  createListener,
+  type KeyboardistListener,
+  type Layer,
+} from "keyboardist";
+import { useEffect, useRef, useState } from "react";
+
+export default function DescriptionsDemo() {
+  const listenerRef = useRef<KeyboardistListener | null>(null);
+  const layerRef = useRef<Layer | null>(null);
+  const [bindings, setBindings] = useState<BindingInfo[]>([]);
+  const [count, setCount] = useState(0);
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  useEffect(() => {
+    const listener = createListener();
+    if (!listener) {
+      return;
+    }
+    listenerRef.current = listener;
+
+    // Each binding documents itself, so the sheet below is generated rather
+    // than hand-maintained.
+    listener.subscribe("up", () => setCount((n) => n + 1), "Adds one");
+    listener.subscribe("down", () => setCount((n) => n - 1), "Subtracts one");
+    listener.subscribe("KeyR", () => setCount(0), {
+      description: "Resets to zero",
+    });
+    // The key that opens the panel is plumbing — it shouldn't list itself.
+    listener.subscribe("shift+slash", () => setPanelOpen((open) => !open), {
+      hidden: true,
+    });
+
+    layerRef.current = listener.layer("panel", {
+      escape: {
+        handler: () => setPanelOpen(false),
+        description: "Closes the panel",
+      },
+      enter: {
+        handler: () => setPanelOpen(false),
+        description: "Confirms and closes",
+      },
+    });
+
+    setBindings(listener.getBindings());
+
+    return () => {
+      layerRef.current?.dispose();
+      listener.stopListening();
+      listenerRef.current = null;
+      layerRef.current = null;
+    };
+  }, []);
+
+  // Push or pop the panel's layer, then re-read the sheet — `active` flips
+  // with the stack, so the listing follows along on its own.
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer) {
+      return;
+    }
+    if (panelOpen) {
+      layer.push();
+    } else {
+      layer.pop();
+    }
+    setBindings(listenerRef.current?.getBindings() ?? []);
+  }, [panelOpen]);
+
+  return (
+    <div>
+      <p className="text-sm text-zinc-600 dark:text-zinc-400">
+        Press <kbd>↑</kbd> <kbd>↓</kbd> <kbd>R</kbd> to change the count, and{" "}
+        <kbd>?</kbd> to open the panel — watch its bindings go active.
+      </p>
+      <p className="mt-3 font-mono text-2xl text-zinc-800 dark:text-zinc-200">
+        {count}
+      </p>
+      {panelOpen ? (
+        <p className="mt-2 rounded-lg bg-zinc-100 p-3 text-sm text-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+          Panel is open — <kbd>Esc</kbd> or <kbd>Enter</kbd> closes it.
+        </p>
+      ) : null}
+      <table className="mt-3 w-full text-left font-mono text-sm">
+        <tbody>
+          {bindings.map((binding) => (
+            <tr
+              key={`${binding.layer}:${binding.key}`}
+              className={binding.active ? undefined : "opacity-40"}
+            >
+              <td className="py-1 pr-4 text-zinc-500">{binding.layer}</td>
+              <td className="py-1 pr-4 text-zinc-800 dark:text-zinc-200">
+                {binding.key}
+              </td>
+              <td className="py-1 text-zinc-600 dark:text-zinc-400">
+                {binding.description ?? "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mt-2 text-xs text-zinc-500">
+        Dimmed rows are bindings that exist but aren't reachable right now. The{" "}
+        <code>shift+slash</code> binding that opens the panel is marked{" "}
+        <code>hidden</code>, so it never appears at all.
+      </p>
+    </div>
+  );
+}

--- a/apps/website/src/routes/core.tsx
+++ b/apps/website/src/routes/core.tsx
@@ -1,6 +1,7 @@
 import { DocsLayout } from "@/components/layout/docs-layout";
 import { P } from "@/components/prose";
 import { usePageTitle } from "@/lib/use-page-title";
+import { DescriptionsSection } from "@/sections/core/descriptions";
 import { ElementSection } from "@/sections/core/element";
 import { KeyNamesSection } from "@/sections/core/key-names";
 import { LayersSection } from "@/sections/core/layers";
@@ -20,6 +21,11 @@ const sections = [
     id: "multiple-listeners",
     title: "Multiple listeners",
     Component: MultipleListenersSection,
+  },
+  {
+    id: "descriptions",
+    title: "Describing bindings",
+    Component: DescriptionsSection,
   },
   { id: "layers", title: "Layers", Component: LayersSection },
   { id: "priority", title: "Priority", Component: PrioritySection },

--- a/apps/website/src/sections/core/descriptions.tsx
+++ b/apps/website/src/sections/core/descriptions.tsx
@@ -1,0 +1,77 @@
+import { CodeBlock } from "@/components/code/code-block";
+import { DemoBlock } from "@/components/demo-block";
+import { Callout, InlineCode, P } from "@/components/prose";
+import DescriptionsDemo from "@/demos/descriptions-demo";
+import descriptionsDemoSource from "@/demos/descriptions-demo.tsx?raw";
+
+export function DescriptionsSection() {
+  return (
+    <>
+      <P>
+        Bindings can carry a description, so your app can build its own shortcut
+        sheet from the bindings that are actually live — no second list to keep
+        in sync. Pass an options object as the third argument, or a bare string
+        as shorthand.
+      </P>
+      <CodeBlock
+        lang="typescript"
+        code={`listener.subscribe(
+  "Down",
+  () => {
+    moveDown();
+  },
+  { description: "Moves down one item" },
+);
+
+// a bare string is shorthand for { description }
+listener.subscribe("Up", moveUp, "Moves up one item");`}
+      />
+      <P>
+        Read them back with <InlineCode>getBindings()</InlineCode>, which now
+        returns the description alongside the layer, key, and active state:
+      </P>
+      <CodeBlock
+        lang="typescript"
+        code={`listener.getBindings();
+// [
+//   { layer: "base", key: "down", active: true, priority: 0,
+//     description: "Moves down one item" },
+//   { layer: "base", key: "up",   active: true, priority: 0,
+//     description: "Moves up one item" },
+// ]`}
+      />
+      <P>
+        In a bindings map, swap the callback for an object to describe it. Bare
+        callbacks keep working, and the two forms mix freely:
+      </P>
+      <CodeBlock
+        lang="typescript"
+        code={`listener.layer("editor", {
+  KeyS: { handler: save, description: "Saves the document" },
+  KeyZ: undo, // undocumented, still bound
+});`}
+      />
+      <P>
+        The listing is grouped by layer rather than flattened by key — the same
+        key can be bound on several layers at once, which is the whole point of
+        layers. Filter on <InlineCode>active</InlineCode> to show only what's
+        reachable right now. Pass <InlineCode>hidden: true</InlineCode> for
+        bindings you don't want on the sheet; they stay fully functional, which
+        is what you want for the shortcut that opens the sheet itself.
+      </P>
+      <Callout>
+        Key names come from <InlineCode>event.code</InlineCode>, so{" "}
+        <InlineCode>?</InlineCode> is <InlineCode>"shift+slash"</InlineCode> on
+        a US layout — subscribing to the literal <InlineCode>"?"</InlineCode>{" "}
+        will never match. On layouts where <InlineCode>?</InlineCode> sits
+        elsewhere, pick the binding that suits your users.
+      </Callout>
+      <DemoBlock
+        source={descriptionsDemoSource}
+        fileName="descriptions-demo.tsx"
+      >
+        <DescriptionsDemo />
+      </DemoBlock>
+    </>
+  );
+}

--- a/packages/keyboardist/README.md
+++ b/packages/keyboardist/README.md
@@ -147,6 +147,70 @@ listener.subscribe("Space", () => {
 // the console will log 'C', then 'B', then 'A' when the spacebar is pressed.
 ```
 
+## Describing bindings
+
+Bindings can carry a description, so your app can build its own shortcut sheet
+from the bindings that are actually live — no second list to keep in sync:
+
+```javascript
+listener.subscribe(
+  "Down",
+  () => {
+    moveDown();
+  },
+  { description: "Moves down one item" },
+);
+
+// a bare string is shorthand for { description }
+listener.subscribe("Up", moveUp, "Moves up one item");
+```
+
+Read them back with `getBindings()`:
+
+```javascript
+listener.getBindings();
+// [
+//   { layer: "base", key: "down", active: true, priority: 0,
+//     description: "Moves down one item" },
+//   { layer: "base", key: "up",   active: true, priority: 0,
+//     description: "Moves up one item" },
+// ]
+```
+
+In a bindings map, swap the callback for an object to describe it. Bare
+callbacks keep working, and the two forms mix freely:
+
+```javascript
+listener.layer("editor", {
+  KeyS: { handler: save, description: "Saves the document" },
+  KeyZ: undo, // undocumented, still bound
+});
+```
+
+Bindings listed by `getBindings()` are grouped by `layer`, not flattened by
+key — the same key can be bound on several layers at once, which is the whole
+point of layers. Use `active` to show only what's reachable right now:
+
+```javascript
+const live = listener.getBindings().filter((binding) => binding.active);
+```
+
+Pass `hidden: true` for bindings you don't want on the sheet. They stay fully
+functional — this is for plumbing, like the shortcut that opens the sheet
+itself:
+
+```javascript
+listener.subscribe("shift+slash", toggleHelp, { hidden: true });
+```
+
+> **Note:** key names come from `event.code`, so `?` is `"shift+slash"` on a
+> US layout. Subscribing to the literal `"?"` will never match. On layouts
+> where `?` isn't shift+slash, pick the binding that suits your users.
+
+When a key has several subscriptions on one layer, the last one subscribed
+wins per field — it's also the first to run, so it's the one the user gets.
+Unsubscribing it falls back to the description beneath.
+
 ## Layers
 
 Bindings can live on named **layers** that stack. The topmost layer with a
@@ -201,8 +265,8 @@ kb.layer("modal", { escape: closeModal }, { priority: 3 });
 component tree automatically — you shouldn't need to set it by hand.)
 
 Inspect the stack at runtime with `kb.activeLayers()` (names, top to bottom,
-ending in `"base"`) and `kb.getBindings()` (every binding with its layer and
-active state).
+ending in `"base"`) and `kb.getBindings()` (every binding with its layer,
+active state, and [description](#describing-bindings)).
 
 ## Key monitor
 
@@ -329,7 +393,8 @@ no peer warnings).
 
 - `useKeyBindings(map)` — global bindings for the component's lifetime.
   Inline objects are fine: callbacks are read through refs, and
-  resubscription only happens when the set of keys changes.
+  resubscription only happens when the keys or their
+  [descriptions](#describing-bindings) change.
 - `useKeyboardLayer(map, { exclusive, active, priority, name })` — a
   [layer](#layers) scoped to the component: created on mount, pushed while
   `active` (default `true`), disposed on unmount. Returns a handle with
@@ -354,6 +419,25 @@ no peer warnings).
 // an input with its own attached listener
 <KeyboardInput bindings={{ up: increment, down: decrement }} ref={inputRef} />
 ```
+
+Any `bindings` prop takes the [described form](#describing-bindings), so a
+component can document its own shortcuts:
+
+```jsx
+<KeyboardLayer
+  bindings={{
+    escape: { handler: close, description: "Closes the dialog" },
+    enter: { handler: submit, description: "Saves and closes" },
+  }}
+  exclusive
+>
+  <Modal />
+</KeyboardLayer>
+```
+
+Because a layer knows which of its bindings are `active`, a help sheet can be
+rendered straight off `getSharedListener().getBindings()` — it updates itself
+as layers push and pop.
 
 ### Nesting is priority
 
@@ -391,12 +475,20 @@ Keyboardist ships its own type definitions:
 ```typescript
 import {
   createListener,
+  type BindingEntry,
+  type BindingInfo,
+  type BindingOptions,
   type KeyboardistListener,
   type Layer,
   type MonitorInfo,
   type Subscription,
 } from "keyboardist";
 ```
+
+`BindingMap` values are `SubscriptionCallback | BindingEntry`, so both the
+bare-callback and [described](#describing-bindings) forms typecheck. One
+wrinkle worth knowing in tests: a bare `vi.fn()` no longer infers against the
+union — give it an implementation (`vi.fn(() => {})`) and it resolves.
 
 ## License
 

--- a/packages/keyboardist/src/index.ts
+++ b/packages/keyboardist/src/index.ts
@@ -2,6 +2,7 @@ import getKeyEventName from "./get-key-event-name";
 import isEditableTarget from "./is-editable-target";
 import isEventModifier from "./is-event-modifier";
 import {
+  type BindingDescriptor,
   type BindingInfo,
   type BindingMap,
   type Layer,
@@ -13,14 +14,18 @@ import {
 import { normalizeKeyName } from "./normalize-key-name";
 
 export type {
+  BindingDescriptor,
+  BindingEntry,
   BindingInfo,
   BindingMap,
+  BindingOptions,
   Layer,
   LayerOptions,
   PopHandle,
   Subscription,
   SubscriptionCallback,
 } from "./layer";
+export { resolveBinding, toBindingOptions } from "./layer";
 export { expandKeyAliases, normalizeKeyName } from "./normalize-key-name";
 
 export type KeyboardEventName = "keydown" | "keyup";
@@ -38,7 +43,11 @@ export interface MonitorInfo {
 export type MonitorCallback = (info: MonitorInfo) => void;
 
 export interface KeyboardistListener {
-  subscribe: (name: string, callback: SubscriptionCallback) => Subscription;
+  subscribe: (
+    name: string,
+    callback: SubscriptionCallback,
+    descriptor?: BindingDescriptor,
+  ) => Subscription;
   layer: (name: string, bindings?: BindingMap, options?: LayerOptions) => Layer;
   activeLayers: () => string[];
   getBindings: () => BindingInfo[];

--- a/packages/keyboardist/src/layer.ts
+++ b/packages/keyboardist/src/layer.ts
@@ -3,7 +3,42 @@ import { expandKeyAliases } from "./normalize-key-name";
 // biome-ignore lint/suspicious/noConfusingVoidType: callbacks may return nothing; `undefined` would reject void-returning functions
 export type SubscriptionCallback = (event: KeyboardEvent) => boolean | void;
 
-export type BindingMap = Record<string, SubscriptionCallback>;
+export interface BindingOptions {
+  /**
+   * What the binding does, in words. Surfaced by `getBindings()`, so a UI
+   * can generate its own shortcut sheet from the live bindings.
+   */
+  description?: string;
+  /** Keeps the binding out of `getBindings()` — for internal plumbing */
+  hidden?: boolean;
+}
+
+/** A bare string is shorthand for `{ description }`. */
+export type BindingDescriptor = string | BindingOptions;
+
+/** A binding written as an object, so it can carry a description. */
+export interface BindingEntry extends BindingOptions {
+  handler: SubscriptionCallback;
+}
+
+export type BindingMap = Record<string, SubscriptionCallback | BindingEntry>;
+
+/** Normalizes the shorthand string form of a descriptor. */
+export function toBindingOptions(
+  descriptor?: BindingDescriptor,
+): BindingOptions {
+  if (typeof descriptor === "string") {
+    return { description: descriptor };
+  }
+  return descriptor ?? {};
+}
+
+/** Normalizes the shorthand bare-callback form of a binding. */
+export function resolveBinding(
+  binding: SubscriptionCallback | BindingEntry,
+): BindingEntry {
+  return typeof binding === "function" ? { handler: binding } : binding;
+}
 
 export interface Subscription {
   unsubscribe: () => void;
@@ -35,7 +70,11 @@ export interface Layer {
   readonly name: string;
   readonly exclusive: boolean;
   readonly priority: number;
-  subscribe: (name: string, callback: SubscriptionCallback) => Subscription;
+  subscribe: (
+    name: string,
+    callback: SubscriptionCallback,
+    descriptor?: BindingDescriptor,
+  ) => Subscription;
   bind: (bindings: BindingMap) => Subscription;
   push: () => PopHandle;
   pop: () => void;
@@ -48,6 +87,8 @@ export interface BindingInfo {
   key: string;
   active: boolean;
   priority: number;
+  /** Present when the binding was subscribed with a description */
+  description?: string;
 }
 
 export type MatchResult =
@@ -55,11 +96,16 @@ export type MatchResult =
   | { type: "swallowed" }
   | { type: "miss" };
 
+/** One subscription: the callback plus whatever it was documented with. */
+interface BindingRecord extends BindingOptions {
+  callback: SubscriptionCallback;
+}
+
 interface LayerState {
   name: string;
   exclusive: boolean;
   priority: number;
-  subscriptions: Map<string, SubscriptionCallback[]>;
+  subscriptions: Map<string, BindingRecord[]>;
 }
 
 export const BASE_LAYER_NAME = "base";
@@ -101,31 +147,39 @@ export class LayerStack {
     const subscribe = (
       keyName: string,
       callback: SubscriptionCallback,
+      descriptor?: BindingDescriptor,
     ): Subscription => {
       const keys = expandKeyAliases(keyName);
+      const record: BindingRecord = {
+        callback,
+        ...toBindingOptions(descriptor),
+      };
       for (const key of keys) {
-        const listeners = state.subscriptions.get(key) ?? [];
-        listeners.push(callback);
-        state.subscriptions.set(key, listeners);
+        const records = state.subscriptions.get(key) ?? [];
+        records.push(record);
+        state.subscriptions.set(key, records);
       }
+      // Removal is by record identity, so subscribing the same callback
+      // twice and unsubscribing once drops only that subscription.
       return makeSubscription(() => {
         for (const key of keys) {
-          const listeners = state.subscriptions.get(key);
-          if (!listeners) {
+          const records = state.subscriptions.get(key);
+          if (!records) {
             continue;
           }
-          const index = listeners.indexOf(callback);
+          const index = records.indexOf(record);
           if (index !== -1) {
-            listeners.splice(index, 1);
+            records.splice(index, 1);
           }
         }
       });
     };
 
     const bind = (map: BindingMap): Subscription => {
-      const subscriptions = Object.entries(map).map(([key, callback]) =>
-        subscribe(key, callback),
-      );
+      const subscriptions = Object.entries(map).map(([key, binding]) => {
+        const { handler, ...options } = resolveBinding(binding);
+        return subscribe(key, handler, options);
+      });
       return makeSubscription(() => {
         for (const subscription of subscriptions) {
           subscription.unsubscribe();
@@ -193,12 +247,12 @@ export class LayerStack {
   match(keyName: string): MatchResult {
     for (let i = this.stack.length - 1; i >= 0; i--) {
       const layer = this.stack[i] as LayerState;
-      const listeners = layer.subscriptions.get(keyName);
-      if (listeners && listeners.length > 0) {
+      const records = layer.subscriptions.get(keyName);
+      if (records && records.length > 0) {
         return {
           type: "match",
           layerName: layer.name,
-          listeners: [...listeners],
+          listeners: records.map((record) => record.callback),
         };
       }
       if (layer.exclusive) {
@@ -212,19 +266,43 @@ export class LayerStack {
     return [...this.stack].reverse().map((state) => state.name);
   }
 
+  /**
+   * Every live binding, with the description it was subscribed with — enough
+   * to render a shortcut sheet. Where a key has several subscriptions in one
+   * layer, the last one subscribed wins per field: it is also the first to
+   * run, so it is the one the user actually gets.
+   */
   getBindings(): BindingInfo[] {
     const bindings: BindingInfo[] = [];
     for (const state of this.states.values()) {
       const active = this.stack.includes(state);
-      for (const [key, listeners] of state.subscriptions) {
-        if (listeners.length > 0) {
-          bindings.push({
-            layer: state.name,
-            key,
-            active,
-            priority: state.priority,
-          });
+      for (const [key, records] of state.subscriptions) {
+        if (records.length === 0) {
+          continue;
         }
+
+        let description: string | undefined;
+        let hidden = false;
+        for (const record of records) {
+          if (record.description !== undefined) {
+            description = record.description;
+          }
+          if (record.hidden !== undefined) {
+            hidden = record.hidden;
+          }
+        }
+
+        if (hidden) {
+          continue;
+        }
+
+        bindings.push({
+          layer: state.name,
+          key,
+          active,
+          priority: state.priority,
+          ...(description !== undefined && { description }),
+        });
       }
     }
     return bindings;

--- a/packages/keyboardist/src/react/index.ts
+++ b/packages/keyboardist/src/react/index.ts
@@ -1,8 +1,11 @@
 "use client";
 
 export type {
+  BindingDescriptor,
+  BindingEntry,
   BindingInfo,
   BindingMap,
+  BindingOptions,
   KeyboardEventName,
   KeyboardistListener,
   Layer,

--- a/packages/keyboardist/src/react/use-element-key-bindings.ts
+++ b/packages/keyboardist/src/react/use-element-key-bindings.ts
@@ -4,7 +4,7 @@ import {
   createListener,
   type KeyboardEventName,
 } from "../index";
-import { keySignatureOf } from "./use-key-bindings";
+import { bindingSignatureOf, subscribeBinding } from "./use-key-bindings";
 import { useLatest } from "./use-latest";
 
 export interface UseElementKeyBindingsOptions {
@@ -23,7 +23,7 @@ export function useElementKeyBindings(
 ): void {
   const { event = "keydown" } = options;
   const bindingsRef = useLatest(bindings);
-  const keySignature = keySignatureOf(bindings);
+  const bindingSignature = bindingSignatureOf(bindings);
   const [element, setElement] = useState<Element | null>(null);
 
   useEffect(() => {
@@ -32,7 +32,7 @@ export function useElementKeyBindings(
     }
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies(keySignature): resubscribes when the key set changes; callbacks are read through bindingsRef
+  // biome-ignore lint/correctness/useExhaustiveDependencies(bindingSignature): resubscribes when the key set or descriptions change; callbacks are read through bindingsRef
   useEffect(() => {
     if (!element) {
       return;
@@ -43,9 +43,7 @@ export function useElementKeyBindings(
     }
 
     const subscriptions = Object.keys(bindingsRef.current).map((key) =>
-      listener.subscribe(key, (keyboardEvent) =>
-        bindingsRef.current[key]?.(keyboardEvent),
-      ),
+      subscribeBinding(listener, bindingsRef, key),
     );
 
     return () => {
@@ -54,5 +52,5 @@ export function useElementKeyBindings(
       }
       listener.stopListening();
     };
-  }, [element, event, keySignature, bindingsRef]);
+  }, [element, event, bindingSignature, bindingsRef]);
 }

--- a/packages/keyboardist/src/react/use-key-bindings.ts
+++ b/packages/keyboardist/src/react/use-key-bindings.ts
@@ -1,5 +1,12 @@
 import { useEffect } from "react";
-import type { BindingMap, KeyboardEventName } from "../index";
+import {
+  type BindingMap,
+  type KeyboardEventName,
+  type KeyboardistListener,
+  type Layer,
+  resolveBinding,
+  type Subscription,
+} from "../index";
 import { getSharedListener } from "./shared-listener";
 import { useLatest } from "./use-latest";
 
@@ -8,16 +15,55 @@ export interface UseKeyBindingsOptions {
 }
 
 // Dependency signature for a bindings map: resubscribe only when the set of
-// keys changes, not on every inline-object identity change. NUL separator —
-// keys themselves may contain commas ("j,k" aliases).
-export function keySignatureOf(bindings: BindingMap): string {
-  return Object.keys(bindings).sort().join("\u0000");
+// keys or their documentation changes, not on every inline-object identity
+// change. Descriptions are captured into the layer at subscribe time, so they
+// belong in the signature — otherwise an edited description would stay stale
+// until the key set happened to change. NUL separator — keys themselves may
+// contain commas ("j,k" aliases).
+export function bindingSignatureOf(bindings: BindingMap): string {
+  return Object.keys(bindings)
+    .sort()
+    .map((key) => {
+      const binding = bindings[key];
+      if (!binding) {
+        return key;
+      }
+      const { description = "", hidden = false } = resolveBinding(binding);
+      return `${key}\u0000${description}\u0000${hidden}`;
+    })
+    .join("\u0000");
+}
+
+/**
+ * Subscribes one key of a bindings map to a layer or listener. The handler is
+ * looked up through the ref on every event, so inline callbacks never force a
+ * resubscribe; the description is read once, at subscribe time, which is why
+ * it has to be part of the dependency signature above.
+ */
+export function subscribeBinding(
+  target: Pick<KeyboardistListener, "subscribe"> | Layer,
+  bindingsRef: { readonly current: BindingMap },
+  key: string,
+): Subscription {
+  const binding = bindingsRef.current[key];
+  const { description, hidden } = binding ? resolveBinding(binding) : {};
+
+  return target.subscribe(
+    key,
+    (keyboardEvent) => {
+      const current = bindingsRef.current[key];
+      return current
+        ? resolveBinding(current).handler(keyboardEvent)
+        : undefined;
+    },
+    { description, hidden },
+  );
 }
 
 /**
  * Subscribes a bindings map on the shared listener while the component is
  * mounted. Inline objects are fine: callbacks are read through a ref, and
- * resubscription only happens when the set of keys changes.
+ * resubscription only happens when the keys or their descriptions change.
  */
 export function useKeyBindings(
   bindings: BindingMap,
@@ -25,9 +71,9 @@ export function useKeyBindings(
 ): void {
   const { event = "keydown" } = options;
   const bindingsRef = useLatest(bindings);
-  const keySignature = keySignatureOf(bindings);
+  const bindingSignature = bindingSignatureOf(bindings);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies(keySignature): resubscribes when the key set changes; callbacks are read through bindingsRef
+  // biome-ignore lint/correctness/useExhaustiveDependencies(bindingSignature): resubscribes when the key set or descriptions change; callbacks are read through bindingsRef
   useEffect(() => {
     const listener = getSharedListener(event);
     if (!listener) {
@@ -35,9 +81,7 @@ export function useKeyBindings(
     }
 
     const subscriptions = Object.keys(bindingsRef.current).map((key) =>
-      listener.subscribe(key, (keyboardEvent) =>
-        bindingsRef.current[key]?.(keyboardEvent),
-      ),
+      subscribeBinding(listener, bindingsRef, key),
     );
 
     return () => {
@@ -45,5 +89,5 @@ export function useKeyBindings(
         subscription.unsubscribe();
       }
     };
-  }, [event, keySignature, bindingsRef]);
+  }, [event, bindingSignature, bindingsRef]);
 }

--- a/packages/keyboardist/src/react/use-keyboard-layer.ts
+++ b/packages/keyboardist/src/react/use-keyboard-layer.ts
@@ -2,7 +2,7 @@ import { useContext, useEffect, useId, useMemo, useRef } from "react";
 import type { BindingMap, KeyboardEventName, Layer } from "../index";
 import { KeyboardDepthContext } from "./depth-context";
 import { getSharedListener } from "./shared-listener";
-import { keySignatureOf } from "./use-key-bindings";
+import { bindingSignatureOf, subscribeBinding } from "./use-key-bindings";
 import { useLatest } from "./use-latest";
 
 export interface UseKeyboardLayerOptions {
@@ -43,7 +43,7 @@ export function useKeyboardLayer(
   const priority = options.priority ?? depth + 1;
 
   const bindingsRef = useLatest(bindings);
-  const keySignature = keySignatureOf(bindings);
+  const bindingSignature = bindingSignatureOf(bindings);
   const layerRef = useRef<Layer | null>(null);
 
   // create the layer for this component's lifetime
@@ -61,23 +61,21 @@ export function useKeyboardLayer(
   }, [event, layerName, exclusive, priority]);
 
   // keep the layer's bindings in sync with the current key set
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-runs after the layer is recreated (event/layerName/exclusive) or when the key set changes (keySignature); callbacks are read through bindingsRef
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-runs after the layer is recreated (event/layerName/exclusive) or when the keys or descriptions change (bindingSignature); callbacks are read through bindingsRef
   useEffect(() => {
     const layer = layerRef.current;
     if (!layer) {
       return;
     }
     const subscriptions = Object.keys(bindingsRef.current).map((key) =>
-      layer.subscribe(key, (keyboardEvent) =>
-        bindingsRef.current[key]?.(keyboardEvent),
-      ),
+      subscribeBinding(layer, bindingsRef, key),
     );
     return () => {
       for (const subscription of subscriptions) {
         subscription.unsubscribe();
       }
     };
-  }, [event, layerName, exclusive, priority, keySignature, bindingsRef]);
+  }, [event, layerName, exclusive, priority, bindingSignature, bindingsRef]);
 
   // push/pop driven by `active`
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-pushes after the layer is recreated by the effect above

--- a/packages/keyboardist/test/descriptions.test.ts
+++ b/packages/keyboardist/test/descriptions.test.ts
@@ -1,0 +1,203 @@
+import { fireEvent } from "@testing-library/dom";
+import { describe, expect, test, vi } from "vitest";
+import { createListener, type KeyboardistListener } from "../src/index";
+
+function createListenerOrThrow(): KeyboardistListener {
+  const listener = createListener();
+  if (!listener) {
+    throw new Error("expected a listener in a DOM environment");
+  }
+  return listener;
+}
+
+function bindingFor(kb: KeyboardistListener, key: string) {
+  return kb.getBindings().find((binding) => binding.key === key);
+}
+
+describe("describing a subscription", () => {
+  test("an options object attaches a description", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("Down", () => {}, { description: "Moves down" });
+
+    expect(bindingFor(kb, "down")).toMatchObject({
+      layer: "base",
+      key: "down",
+      active: true,
+      description: "Moves down",
+    });
+  });
+
+  test("a bare string is shorthand for a description", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("Up", () => {}, "Moves up");
+
+    expect(bindingFor(kb, "up")?.description).toBe("Moves up");
+  });
+
+  test("an undescribed binding has no description key at all", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("KeyQ", () => {});
+
+    const binding = bindingFor(kb, "q");
+    expect(binding).toBeDefined();
+    expect(binding).not.toHaveProperty("description");
+  });
+
+  test("describing a binding does not disturb what it does", () => {
+    const kb = createListenerOrThrow();
+    const callback = vi.fn();
+    kb.subscribe("KeyE", callback, "Does a thing");
+
+    fireEvent.keyDown(document, { code: "KeyE" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("a description reaches every key of an alias list", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("j,k", () => {}, "Moves through the list");
+
+    expect(bindingFor(kb, "j")?.description).toBe("Moves through the list");
+    expect(bindingFor(kb, "k")?.description).toBe("Moves through the list");
+  });
+
+  test("unsubscribing takes the description with it", () => {
+    const kb = createListenerOrThrow();
+    const subscription = kb.subscribe("KeyT", () => {}, "Temporary");
+
+    expect(bindingFor(kb, "t")?.description).toBe("Temporary");
+    subscription.unsubscribe();
+    expect(bindingFor(kb, "t")).toBeUndefined();
+  });
+});
+
+describe("descriptions in a bindings map", () => {
+  test("the object form carries a description", () => {
+    const kb = createListenerOrThrow();
+    const callback = vi.fn();
+    kb.layer("editor", {
+      KeyS: { handler: callback, description: "Saves the document" },
+    }).push();
+
+    expect(bindingFor(kb, "s")).toMatchObject({
+      layer: "editor",
+      description: "Saves the document",
+    });
+
+    fireEvent.keyDown(document, { code: "KeyS" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("bare callbacks and described bindings mix in one map", () => {
+    const kb = createListenerOrThrow();
+    kb.layer("mixed", {
+      KeyA: () => {},
+      KeyB: { handler: () => {}, description: "Bee" },
+    }).push();
+
+    expect(bindingFor(kb, "a")).not.toHaveProperty("description");
+    expect(bindingFor(kb, "b")?.description).toBe("Bee");
+  });
+});
+
+describe("hidden bindings", () => {
+  test("a hidden binding stays out of getBindings", () => {
+    const kb = createListenerOrThrow();
+    const callback = vi.fn();
+    kb.subscribe("shift+slash", callback, { hidden: true });
+
+    expect(bindingFor(kb, "shift+slash")).toBeUndefined();
+  });
+
+  test("a hidden binding still fires", () => {
+    const kb = createListenerOrThrow();
+    const callback = vi.fn();
+    kb.subscribe("KeyH", callback, { hidden: true });
+
+    fireEvent.keyDown(document, { code: "KeyH" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("several subscriptions on one key", () => {
+  test("the last description subscribed wins", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("KeyM", () => {}, "First");
+    kb.subscribe("KeyM", () => {}, "Second");
+
+    expect(bindingFor(kb, "m")?.description).toBe("Second");
+  });
+
+  test("an undescribed later subscription keeps the earlier description", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("KeyN", () => {}, "Documented");
+    kb.subscribe("KeyN", () => {});
+
+    expect(bindingFor(kb, "n")?.description).toBe("Documented");
+  });
+
+  test("unsubscribing the winner falls back to the earlier description", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("KeyO", () => {}, "Original");
+    const second = kb.subscribe("KeyO", () => {}, "Override");
+
+    expect(bindingFor(kb, "o")?.description).toBe("Override");
+    second.unsubscribe();
+    expect(bindingFor(kb, "o")?.description).toBe("Original");
+  });
+
+  test("unsubscribing one of two identical callbacks leaves the other", () => {
+    const kb = createListenerOrThrow();
+    const callback = vi.fn();
+    const first = kb.subscribe("KeyP", callback);
+    kb.subscribe("KeyP", callback);
+
+    first.unsubscribe();
+    fireEvent.keyDown(document, { code: "KeyP" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("descriptions across layers", () => {
+  test("the same key keeps a separate description per layer", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("Escape", () => {}, "Clears the search");
+    const modal = kb.layer("modal", {
+      Escape: { handler: () => {}, description: "Closes the modal" },
+    });
+    modal.push();
+
+    const escapes = kb
+      .getBindings()
+      .filter((binding) => binding.key === "escape");
+
+    expect(escapes).toHaveLength(2);
+    expect(
+      escapes.find((binding) => binding.layer === "base")?.description,
+    ).toBe("Clears the search");
+    expect(
+      escapes.find((binding) => binding.layer === "modal")?.description,
+    ).toBe("Closes the modal");
+  });
+
+  test("active tells a help sheet which description is live", () => {
+    const kb = createListenerOrThrow();
+    kb.subscribe("Escape", () => {}, "Clears the search");
+    const modal = kb.layer("modal", {
+      Escape: { handler: () => {}, description: "Closes the modal" },
+    });
+
+    const liveBefore = kb
+      .getBindings()
+      .filter((binding) => binding.key === "escape" && binding.active);
+    expect(liveBefore.map((binding) => binding.layer)).toEqual(["base"]);
+
+    modal.push();
+    const liveAfter = kb
+      .getBindings()
+      .filter((binding) => binding.key === "escape" && binding.active);
+    expect(liveAfter.map((binding) => binding.layer).sort()).toEqual([
+      "base",
+      "modal",
+    ]);
+  });
+});

--- a/packages/keyboardist/test/disposables.test.ts
+++ b/packages/keyboardist/test/disposables.test.ts
@@ -36,7 +36,7 @@ describe("explicit resource management", () => {
 
   test("double dispose is a no-op", () => {
     const kb = createListenerOrThrow();
-    const layer = kb.layer("double-dispose", { Digit9: vi.fn() });
+    const layer = kb.layer("double-dispose", { Digit9: vi.fn(() => {}) });
 
     const handle = layer.push();
     handle();

--- a/packages/keyboardist/test/layers.test.ts
+++ b/packages/keyboardist/test/layers.test.ts
@@ -66,7 +66,7 @@ describe("layer basics", () => {
 
   test("dispose pops and removes the layer definition", () => {
     const kb = createListenerOrThrow();
-    const layer = kb.layer("disposable", { KeyR: vi.fn() });
+    const layer = kb.layer("disposable", { KeyR: vi.fn(() => {}) });
     layer.push();
     layer.dispose();
     expect(layer.isActive()).toBe(false);
@@ -97,7 +97,7 @@ describe("dispatch rules", () => {
     const kb = createListenerOrThrow();
     const baseCallback = vi.fn();
     kb.subscribe("KeyY", baseCallback);
-    kb.layer("fallthrough-modal", { escape: vi.fn() }).push();
+    kb.layer("fallthrough-modal", { escape: vi.fn(() => {}) }).push();
 
     fireEvent.keyDown(document, { code: "KeyY" });
     expect(baseCallback).toHaveBeenCalled();
@@ -344,7 +344,7 @@ describe("layer priority", () => {
 
   test("getBindings reports priority", () => {
     const kb = createListenerOrThrow();
-    kb.layer("prio-bindings", { Digit6: vi.fn() }, { priority: 7 });
+    kb.layer("prio-bindings", { Digit6: vi.fn(() => {}) }, { priority: 7 });
 
     expect(kb.getBindings()).toContainEqual({
       layer: "prio-bindings",

--- a/packages/keyboardist/test/monitor.test.ts
+++ b/packages/keyboardist/test/monitor.test.ts
@@ -30,7 +30,7 @@ describe("structured monitor", () => {
   test("reports matched=true and the layer name on a hit", () => {
     const kb = createListenerOrThrow();
     const monitor = vi.fn();
-    const layer = kb.layer("monitored-layer", { Period: vi.fn() });
+    const layer = kb.layer("monitored-layer", { Period: vi.fn(() => {}) });
     layer.push();
     kb.setMonitor(monitor);
 
@@ -106,7 +106,9 @@ describe("introspection", () => {
   test("getBindings lists bindings with their layer and active state", () => {
     const kb = createListenerOrThrow();
     kb.subscribe("Backslash", vi.fn());
-    const layer = kb.layer("intro-bindings", { "shift+Backslash": vi.fn() });
+    const layer = kb.layer("intro-bindings", {
+      "shift+Backslash": vi.fn(() => {}),
+    });
 
     expect(kb.getBindings()).toContainEqual({
       layer: "base",

--- a/packages/keyboardist/test/react/descriptions.test.tsx
+++ b/packages/keyboardist/test/react/descriptions.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent } from "@testing-library/dom";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import type { BindingInfo } from "../../src/index";
+import { getSharedListener } from "../../src/react/shared-listener";
+import { useKeyBindings } from "../../src/react/use-key-bindings";
+import { useKeyboardLayer } from "../../src/react/use-keyboard-layer";
+
+function bindingFor(key: string): BindingInfo | undefined {
+  const listener = getSharedListener();
+  if (!listener) {
+    throw new Error("expected a shared listener in a DOM environment");
+  }
+  return listener.getBindings().find((binding) => binding.key === key);
+}
+
+describe("useKeyBindings descriptions", () => {
+  test("the object form documents a binding", () => {
+    const callback = vi.fn();
+    renderHook(() =>
+      useKeyBindings({
+        KeyA: { handler: callback, description: "Selects all" },
+      }),
+    );
+
+    expect(bindingFor("a")?.description).toBe("Selects all");
+    fireEvent.keyDown(document, { code: "KeyA" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("editing a description updates it without changing the key set", () => {
+    // Regression guard: descriptions are captured at subscribe time, so the
+    // dependency signature has to notice them changing on their own.
+    const { rerender } = renderHook(
+      ({ description }) =>
+        useKeyBindings({ KeyB: { handler: () => {}, description } }),
+      { initialProps: { description: "Before" } },
+    );
+
+    expect(bindingFor("b")?.description).toBe("Before");
+
+    rerender({ description: "After" });
+    expect(bindingFor("b")?.description).toBe("After");
+  });
+
+  test("a rerender with an unchanged description does not duplicate", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ cb }) =>
+        useKeyBindings({ KeyC: { handler: cb, description: "Same" } }),
+      { initialProps: { cb: callback } },
+    );
+
+    rerender({ cb: callback });
+    rerender({ cb: callback });
+
+    fireEvent.keyDown(document, { code: "KeyC" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("unmount removes the documented binding", () => {
+    const { unmount } = renderHook(() =>
+      useKeyBindings({ KeyD: { handler: () => {}, description: "Gone soon" } }),
+    );
+
+    expect(bindingFor("d")?.description).toBe("Gone soon");
+    unmount();
+    expect(bindingFor("d")).toBeUndefined();
+  });
+
+  test("a bare callback still works alongside documented ones", () => {
+    const bare = vi.fn();
+    renderHook(() =>
+      useKeyBindings({
+        KeyE: bare,
+        KeyF: { handler: () => {}, description: "Documented" },
+      }),
+    );
+
+    fireEvent.keyDown(document, { code: "KeyE" });
+    expect(bare).toHaveBeenCalledTimes(1);
+    expect(bindingFor("e")).not.toHaveProperty("description");
+    expect(bindingFor("f")?.description).toBe("Documented");
+  });
+
+  test("the latest handler runs even when only the description changed", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ cb, description }) =>
+        useKeyBindings({ KeyG: { handler: cb, description } }),
+      { initialProps: { cb: first, description: "One" } },
+    );
+
+    rerender({ cb: second, description: "Two" });
+    fireEvent.keyDown(document, { code: "KeyG" });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useKeyboardLayer descriptions", () => {
+  test("a layer's bindings carry their descriptions", () => {
+    renderHook(() =>
+      useKeyboardLayer(
+        { KeyH: { handler: () => {}, description: "Shows help" } },
+        { name: "help-layer" },
+      ),
+    );
+
+    expect(bindingFor("h")).toMatchObject({
+      layer: "help-layer",
+      description: "Shows help",
+      active: true,
+    });
+  });
+
+  test("hidden bindings stay out of a layer's listing but still fire", () => {
+    const callback = vi.fn();
+    renderHook(() =>
+      useKeyboardLayer(
+        { KeyI: { handler: callback, hidden: true } },
+        { name: "hidden-layer" },
+      ),
+    );
+
+    expect(bindingFor("i")).toBeUndefined();
+    fireEvent.keyDown(document, { code: "KeyI" });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/keyboardist/test/react/use-keyboard-layer.test.tsx
+++ b/packages/keyboardist/test/react/use-keyboard-layer.test.tsx
@@ -42,7 +42,7 @@ describe("useKeyboardLayer", () => {
       useKeyBindings({ KeyK: baseCallback }),
     );
     const { unmount: unmountLayer } = renderHook(() =>
-      useKeyboardLayer({ KeyL: vi.fn() }, { exclusive: true }),
+      useKeyboardLayer({ KeyL: vi.fn(() => {}) }, { exclusive: true }),
     );
 
     fireEvent.keyDown(document, { code: "KeyK" });


### PR DESCRIPTION
Bindings can now describe themselves, so an app can generate its shortcut sheet from the bindings that are actually live instead of hand-maintaining a second list.

```js
listener.subscribe("Down", moveDown, { description: "Moves down one item" });
listener.subscribe("Up", moveUp, "Moves up one item"); // string shorthand

listener.getBindings();
// [{ layer: "base", key: "down", active: true, priority: 0,
//    description: "Moves down one item" }, ...]
```

## Design notes

**`getBindings()` rather than a new method.** It already returned `{layer, key, active, priority}`; `description` just joins it. A second method returning a different shape for the same data would be two things to keep in sync.

**Grouped by layer, not flattened by key.** A flat `{ Down: {...} }` record can't represent the same key bound on several layers — which is the entire point of layers, and exactly what a per-layer help sheet needs. `active` tells the sheet which binding is reachable right now.

**`{ description, hidden }` rather than a `metadata` field.** An options object leaves room for `group`/`label` later without a rename. `hidden` earns its place on day one: the shortcut that opens the sheet shouldn't appear on it.

**Last subscription wins, per field.** It's also the first to run, so it's the one the user gets. Unsubscribing it falls back to the description beneath.

## The typing hurdle

`BindingMap` values become `SubscriptionCallback | BindingEntry`. One `typeof v === "function"` narrowing in `bind()` covers it, and the change is backward compatible — inline arrows (with `event` still inferred), named functions, and the object form all typecheck.

One casualty, type-level only: a bare `vi.fn()` no longer infers against the union, because its generic stays `Constructable | Procedure`. Giving it an implementation (`vi.fn(() => {})`) resolves it; seven test sites updated. No application-code form is affected, and this is documented in the README's TypeScript section.

## Bug fixed along the way

The React hooks computed their resubscribe signature from `Object.keys()` alone. Descriptions are captured into the layer at subscribe time, so editing one without touching the key set would have left the old text stuck permanently. The signature now folds in descriptions — `bindingSignatureOf` replaces `keySignatureOf`. There's a regression test for it, verified to fail against the old signature.

## Docs

README gets a "Describing bindings" section; the website gets a matching section with a live demo whose shortcut sheet is generated from `getBindings()` and updates as the panel's layer pushes and pops.

Both note that key names come from `event.code`, so `?` is `"shift+slash"` on a US layout — subscribing to the literal `"?"` never matches.

## Checks

Lint, typecheck, 120 tests (24 new), build, and export validation all pass locally. The website section was **not** verified in a browser — the Chrome extension wasn't connected — but the StrictMode double-mount pattern the demo relies on was verified with a throwaway test.

Follow-up PR: the optional auto-bound `?` help overlay, headless, with the styled version living on the website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)