### PR TITLE
Fix CI: website typecheck no longer needs a built dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist
 coverage
 *.log
 .DS_Store
+
+# Local Netlify folder
+.netlify

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -4,7 +4,9 @@
     "jsx": "react-jsx",
     "types": ["vite/client"],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "keyboardist": ["../../packages/keyboardist/src/index.ts"],
+      "keyboardist/react": ["../../packages/keyboardist/src/react/index.ts"]
     }
   },
   "include": ["src", "vite.config.ts"]


### PR DESCRIPTION
CI has been red on master (and on every dependabot PR) since the monorepo merge — the dependabot bumps themselves are innocent.

**Cause:** the CI job typechecks before building. `apps/website` imports `keyboardist` / `keyboardist/react`, which TypeScript resolves through the workspace link to `packages/keyboardist/dist/` — absent on a fresh checkout, so every import failed with TS2307 (plus downstream implicit-any errors in the monitor demos).

**Fix:** mirror the existing Vite source aliases as `tsconfig` `paths`, so `tsc` typechecks against the library source exactly like Vite bundles it. Typecheck is now independent of build order and works on a clean checkout.

Verified locally by removing `dist/` and running `pnpm -r typecheck` (passes), plus `pnpm lint`.

Merging this unblocks #54, #55, #57, and #58 (which should clear the 4 open Dependabot security alerts) once they're rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)